### PR TITLE
feat: File watcher

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -15,6 +15,7 @@ export default [
         'error',
         {
           args: 'all',
+          argsIgnorePattern: '^_',
           varsIgnorePattern: '^_',
         },
       ],

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -25,6 +25,20 @@
       "outputs": ["{workspaceRoot}/coverage/packages/core"],
       "dependsOn": ["^build"]
     },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "eslint packages/core/src"
+      },
+      "cache": true,
+      "inputs": [
+        "default",
+        "{workspaceRoot}/eslint.config.mts",
+        {
+          "externalDependencies": ["eslint"]
+        }
+      ]
+    },
     "nx-release-publish": {
       "executor": "@nx/js:release-publish",
       "dependsOn": ["^nx-release-publish"],

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -22,3 +22,6 @@ export type {
 export type { NormalizedFederationConfig } from './lib/domain/config/federation-config.contract.js';
 export { getDefaultCachePath, getChecksum } from './lib/utils/cache-persistence.js';
 export { isInSkipList, prepareSkipList } from './lib/config/default-skip-list.js';
+
+export { NfFileWatcher, NfFileWatcherOptions } from './lib/domain/utils/file-watcher.contract.js';
+export { syncNfFileWatcher, createNfWatcher } from './lib/utils/file-watcher.js';

--- a/packages/core/src/lib/domain/utils/file-watcher.contract.ts
+++ b/packages/core/src/lib/domain/utils/file-watcher.contract.ts
@@ -1,0 +1,11 @@
+export interface NfFileWatcherOptions {
+  onChange?: (path: string) => void;
+}
+
+export interface NfFileWatcher {
+  addPaths(paths: string | readonly string[]): void;
+  close(): Promise<void>;
+  get(): ReadonlySet<string>;
+  clear(): void;
+  mutate(fn: (dirtyPaths: Set<string>) => void): void;
+}

--- a/packages/core/src/lib/utils/file-watcher.ts
+++ b/packages/core/src/lib/utils/file-watcher.ts
@@ -1,0 +1,56 @@
+import { logger } from '@softarc/native-federation/internal';
+import { watch, statSync, type FSWatcher } from 'fs';
+import { join } from 'path';
+import type { NfFileWatcher, NfFileWatcherOptions } from '../domain/utils/file-watcher.contract.js';
+
+const toUnix = (p: string) => p.replace(/\\/g, '/');
+
+export function createNfWatcher(options: NfFileWatcherOptions = {}): NfFileWatcher {
+  const { onChange } = options;
+  const watchers = new Map<string, FSWatcher>();
+  const dirtyPaths = new Set<string>();
+
+  const notify = (path: string) => {
+    if (onChange) onChange(path);
+    else dirtyPaths.add(path);
+  };
+
+  return {
+    addPaths(paths) {
+      const list = typeof paths === 'string' ? [paths] : [...paths];
+      for (const p of list) {
+        if (watchers.has(p)) continue;
+        try {
+          const isDir = statSync(p).isDirectory();
+          const w = isDir
+            ? watch(p, { recursive: true }, (_, filename) => {
+                if (filename) notify(toUnix(join(p, filename)));
+              })
+            : watch(p, () => notify(toUnix(p)));
+          watchers.set(p, w);
+        } catch {
+          logger.debug(`Could not watch path '${p}'.`);
+        }
+      }
+    },
+
+    get: () => dirtyPaths,
+    clear: () => dirtyPaths.clear(),
+    mutate: fn => fn(dirtyPaths),
+
+    async close() {
+      for (const w of watchers.values()) {
+        w.close();
+      }
+      watchers.clear();
+    },
+  };
+}
+
+export function syncNfFileWatcher(
+  watcher: NfFileWatcher,
+  bundlerCache: { keys(): IterableIterator<string> }
+): void {
+  const files = [...bundlerCache.keys()].filter(k => !k.includes('node_modules'));
+  if (files.length) watcher.addPaths(files);
+}

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -37,6 +37,6 @@
     }
   },
   "dependencies": {
-    "@softarc/native-federation-runtime": "4.0.0-RC9"
+    "@softarc/native-federation-runtime": "4.0.0-RC10"
   }
 }


### PR DESCRIPTION
This pull request introduces a file watcher utility to the `core` package and improves both code usability and project tooling. The main changes include the addition of a new file watcher API, its implementation, and integration, as well as enhancements to linting configuration and rules.

**File watcher utility:**

* Introduced the `NfFileWatcher` and `NfFileWatcherOptions` interfaces to define a standard API for file watching in `file-watcher.contract.ts`.
* Implemented the file watcher logic in `file-watcher.ts`, providing functions to create and synchronize file watchers, handle file changes, and manage watched paths.
* Exported the new file watcher types and functions from `internal.ts` for use throughout the codebase.

**Tooling and configuration improvements:**

* Added a `lint` target to `packages/core/project.json`, enabling linting of the `core` package source files with caching and dependency tracking.
* Updated the ESLint configuration to ignore unused arguments that start with an underscore, reducing unnecessary lint errors for intentionally unused variables.