### PR TITLE
chore: Fixed chunk bug

### DIFF
--- a/packages/core/src/lib/core/bundle-exposed-and-mappings.ts
+++ b/packages/core/src/lib/core/bundle-exposed-and-mappings.ts
@@ -80,7 +80,10 @@ export async function bundleExposedAndMappings(
     throw error;
   }
 
-  const resultMap = createBuildResultMap(result, hash);
+  const resultMap = createBuildResultMap(result, hash, [
+    ...shared.map(s => s.outName),
+    ...exposes.map(e => e.outName),
+  ]);
 
   const sharedResult: Array<SharedInfo> = [];
   const entryFiles: string[] = [];

--- a/packages/core/src/lib/utils/build-result-map.ts
+++ b/packages/core/src/lib/utils/build-result-map.ts
@@ -1,22 +1,25 @@
 import path from 'path';
 import type { NFBuildAdapterResult } from '../domain/core/build-adapter.contract.js';
 
+function stripHash(fileName: string): string {
+  const start = fileName.lastIndexOf('-');
+  const end = fileName.lastIndexOf('.');
+  if (start < 0 || end < 0 || start > end) return fileName;
+  return fileName.substring(0, start) + fileName.substring(end);
+}
+
 export function createBuildResultMap(
   buildResult: NFBuildAdapterResult[],
-  isHashed: boolean
+  isHashed: boolean,
+  expectedNames: string[] = []
 ): Record<string, string> {
+  const expected = new Set(expectedNames.map(n => path.basename(n)));
   const map: Record<string, string> = {};
 
   for (const item of buildResult) {
     const resultName = path.basename(item.fileName);
-    let requestName = resultName;
-    if (isHashed) {
-      const start = resultName.lastIndexOf('-');
-      const end = resultName.lastIndexOf('.');
-      const part1 = resultName.substring(0, start);
-      const part2 = resultName.substring(end);
-      requestName = part1 + part2;
-    }
+    const requestName =
+      isHashed && expected.has(stripHash(resultName)) ? stripHash(resultName) : resultName;
     map[requestName] = item.fileName;
   }
   return map;


### PR DESCRIPTION
Closes #39 

This pull request refactors and improves the `createBuildResultMap` utility function in `build-result-map.ts` for more robust handling of hashed file names. The main change is the introduction of a new `stripHash` helper and an `expectedNames` parameter, making hash stripping conditional and more reliable.

**Improvements to Hashed File Name Handling:**

* Added a `stripHash` helper function to reliably remove hashes from file names when needed.
* Updated `createBuildResultMap` to accept an optional `expectedNames` array, using it to determine when to strip hashes from file names. Hashes are now only stripped if the stripped name is in the expected set, making the mapping more accurate.