### PR TITLE
chore: Fixed find-shared-library-version and changed to opt-out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,7 @@ export default withNativeFederation({
 
   features: {
     denseChunking: true, // Optimize remoteEntry.json structure
-    mappingVersion: true, // Use versions for shared mappings
+    mappingVersion: true, // Use versions for shared mappings, is now opt-out
   },
 });
 ```

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Notes:
 - Mapped paths are read from the workspace root tsconfig file: `tsconfig.base.json` if present, otherwise `tsconfig.json`.
 - The workspace root is detected by searching upward from the current working directory until a `package.json` is found.
 
-If you want to share libraries within a monorepo and also distribute them as built libraries with a version, enable the `mappingVersion` feature flag in your `federation.config.js`. This ensures that the corresponding versions from your buildable libraries are used.
+If you don't want to share libraries within a monorepo and also distribute them as built libraries with a version, disable the `mappingVersion` feature flag in your `federation.config.js`. This ensures that the corresponding versions from your buildable libraries are used.
 
 ```js
 module.exports = withNativeFederation({
@@ -389,7 +389,7 @@ module.exports = withNativeFederation({
   },
   sharedMappings: ['@my-org/auth-lib', '@my-org/ui/*'],
   features: {
-    mappingVersion: true,
+    mappingVersion: false,
   },
 });
 ```

--- a/packages/core/src/lib/config/with-native-federation.ts
+++ b/packages/core/src/lib/config/with-native-federation.ts
@@ -28,7 +28,7 @@ export function withNativeFederation(config: FederationConfig): NormalizedFedera
     skip,
     externals: config.externals ?? [],
     features: {
-      mappingVersion: config.features?.mappingVersion ?? false,
+      mappingVersion: config.features?.mappingVersion ?? true,
       ignoreUnusedDeps: config.features?.ignoreUnusedDeps ?? true,
       denseChunking: config.features?.denseChunking ?? false,
     },

--- a/packages/core/src/lib/core/bundle-exposed-and-mappings.spec.ts
+++ b/packages/core/src/lib/core/bundle-exposed-and-mappings.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { getMappingVersion } from './bundle-exposed-and-mappings.js';
+import { logger } from '../utils/logger.js';
+
+describe('getMappingVersion', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'mapping-version-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  function write(relPath: string, contents: string) {
+    const full = path.join(tmpRoot, relPath);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, contents);
+    return full;
+  }
+
+  it('returns version from the nearest package.json walking up from a deep entry', () => {
+    write('libs/shared/package.json', JSON.stringify({ version: '1.2.3' }));
+    const entry = write('libs/shared/src/lib/index.ts', '');
+
+    expect(getMappingVersion(entry, tmpRoot)).toBe('1.2.3');
+  });
+
+  it('returns version when package.json sits next to the entry file', () => {
+    write('libs/shared/package.json', JSON.stringify({ version: '4.5.6' }));
+    const entry = write('libs/shared/index.ts', '');
+
+    expect(getMappingVersion(entry, tmpRoot)).toBe('4.5.6');
+  });
+
+  it('falls back to the workspace package.json when no closer one is found', () => {
+    write('package.json', JSON.stringify({ version: '9.9.9' }));
+    const entry = write('libs/shared/src/lib/index.ts', '');
+
+    expect(getMappingVersion(entry, tmpRoot)).toBe('9.9.9');
+  });
+
+  it('skips a package.json without a version and keeps walking up', () => {
+    write('libs/shared/package.json', JSON.stringify({ name: 'shared' }));
+    write('package.json', JSON.stringify({ version: '7.0.0' }));
+    const entry = write('libs/shared/src/index.ts', '');
+
+    expect(getMappingVersion(entry, tmpRoot)).toBe('7.0.0');
+  });
+
+  it('returns "" and warns when a package.json is malformed', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    write('libs/shared/package.json', '{ not json');
+    const entry = write('libs/shared/src/index.ts', '');
+
+    expect(getMappingVersion(entry, tmpRoot)).toBe('');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to parse')
+    );
+  });
+
+  it('returns "" when no package.json exists at or above the entry within the workspace', () => {
+    const entry = write('libs/shared/src/index.ts', '');
+
+    expect(getMappingVersion(entry, tmpRoot)).toBe('');
+  });
+
+  it('does not walk above workspaceRoot', () => {
+    const outerVersion = JSON.stringify({ version: 'should-not-be-used' });
+    const outer = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'mapping-version-outer-'));
+    fs.writeFileSync(path.join(outer, 'package.json'), outerVersion);
+    const innerRoot = path.join(outer, 'workspace');
+    fs.mkdirSync(innerRoot);
+    const entry = path.join(innerRoot, 'libs/shared/src/index.ts');
+    fs.mkdirSync(path.dirname(entry), { recursive: true });
+    fs.writeFileSync(entry, '');
+
+    try {
+      expect(getMappingVersion(entry, innerRoot)).toBe('');
+    } finally {
+      fs.rmSync(outer, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/lib/core/bundle-exposed-and-mappings.ts
+++ b/packages/core/src/lib/core/bundle-exposed-and-mappings.ts
@@ -97,7 +97,9 @@ export async function bundleExposedAndMappings(
       requiredVersion: '',
       singleton: true,
       strictVersion: false,
-      version: config.features.mappingVersion ? getMappingVersion(item.fileName) : '',
+      version: config.features.mappingVersion
+        ? getMappingVersion(item.fileName, fedOptions.workspaceRoot)
+        : '',
       dev: !fedOptions.dev
         ? undefined
         : {
@@ -180,7 +182,9 @@ export function describeSharedMappings(
       requiredVersion: '',
       singleton: true,
       strictVersion: false,
-      version: config.features.mappingVersion ? getMappingVersion(mappedPath) : '',
+      version: config.features.mappingVersion
+        ? getMappingVersion(mappedPath, fedOptions.workspaceRoot)
+        : '',
       dev: !fedOptions.dev
         ? undefined
         : {
@@ -192,15 +196,22 @@ export function describeSharedMappings(
   return result;
 }
 
-function getMappingVersion(fileName: string): string {
-  const entryFileDir = path.dirname(fileName);
-  const cand1 = path.join(entryFileDir, 'package.json');
-  const cand2 = path.join(path.dirname(entryFileDir), 'package.json');
+export function getMappingVersion(fileName: string, workspaceRoot: string): string {
+  const resolvedRoot = path.resolve(workspaceRoot);
+  let dir = path.dirname(path.resolve(fileName));
 
-  const packageJsonPath = [cand1, cand2].find(cand => fs.existsSync(cand));
-  if (packageJsonPath) {
-    const json = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
-    return json.version ?? '';
+  while (true) {
+    const candidate = path.join(dir, 'package.json');
+    try {
+      const json = JSON.parse(fs.readFileSync(candidate, 'utf-8'));
+      if (typeof json.version === 'string' && json.version) return json.version;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        logger.warn(`[getMappingVersion] Failed to parse ${candidate}: ${(err as Error).message}`);
+      }
+    }
+    const parent = path.dirname(dir);
+    if (dir === resolvedRoot || parent === dir) return '';
+    dir = parent;
   }
-  return '';
 }

--- a/packages/core/src/lib/core/bundle-exposed-and-mappings.ts
+++ b/packages/core/src/lib/core/bundle-exposed-and-mappings.ts
@@ -93,21 +93,9 @@ export async function bundleExposedAndMappings(
   // Pick shared-mappings
   for (const item of shared) {
     const distEntryFile = popFromResultMap(resultMap, item.outName);
-    sharedResult.push({
-      packageName: item.key!,
-      outFileName: path.basename(distEntryFile),
-      requiredVersion: '',
-      singleton: true,
-      strictVersion: false,
-      version: config.features.mappingVersion
-        ? getMappingVersion(item.fileName, fedOptions.workspaceRoot)
-        : '',
-      dev: !fedOptions.dev
-        ? undefined
-        : {
-            entryPoint: normalize(path.normalize(item.fileName)),
-          },
-    });
+    sharedResult.push(
+      toSharedMappingInfo(item.fileName, item.key!, path.basename(distEntryFile), config, fedOptions)
+    );
     entryFiles.push(distEntryFile);
   }
 
@@ -190,24 +178,35 @@ export function describeSharedMappings(
   const result: Array<SharedInfo> = [];
 
   for (const [mappedPath, mappedImport] of Object.entries(config.sharedMappings)) {
-    result.push({
-      packageName: mappedImport,
-      outFileName: '',
-      requiredVersion: '',
-      singleton: true,
-      strictVersion: false,
-      version: config.features.mappingVersion
-        ? getMappingVersion(mappedPath, fedOptions.workspaceRoot)
-        : '',
-      dev: !fedOptions.dev
-        ? undefined
-        : {
-            entryPoint: normalize(path.normalize(mappedPath)),
-          },
-    });
+    result.push(toSharedMappingInfo(mappedPath, mappedImport, '', config, fedOptions));
   }
 
   return result;
+}
+
+function toSharedMappingInfo(
+  mappedPath: string,
+  mappedImport: string,
+  outFileName: string,
+  config: NormalizedFederationConfig,
+  fedOptions: NormalizedFederationOptions
+): SharedInfo {
+  const mappingVersion = config.features.mappingVersion
+    ? getMappingVersion(mappedPath, fedOptions.workspaceRoot)
+    : '';
+  return {
+    packageName: mappedImport,
+    outFileName,
+    requiredVersion: mappingVersion.length > 0 ? '~' + mappingVersion : '',
+    singleton: true,
+    strictVersion: config.features.mappingVersion,
+    version: mappingVersion,
+    dev: !fedOptions.dev
+      ? undefined
+      : {
+          entryPoint: normalize(path.normalize(mappedPath)),
+        },
+  };
 }
 
 export function getMappingVersion(fileName: string, workspaceRoot: string): string {


### PR DESCRIPTION
Closes #46 

This pull request introduces significant improvements to how the `mappingVersion` feature flag is handled in the module federation configuration. The default behavior for versioned shared mappings is now opt-out (enabled by default), and the logic for version detection has been refactored and thoroughly tested. Documentation has been updated to reflect these changes.

**Feature flag and configuration changes:**

* The `mappingVersion` feature is now enabled by default, making versioned shared mappings opt-out instead of opt-in. This is reflected in both the code (`with-native-federation.ts`) and documentation (`README.md`, `AGENTS.md`). [[1]](diffhunk://#diff-319207b5f23e1cad4b1bf54fe0ba8da92f1409ca1fb094fa57b4247123644b1bL31-R31) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L224-R224) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L379-R379) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L392-R392)

**Version detection and mapping logic:**

* The logic for determining the version of a shared mapping has been refactored: `getMappingVersion` now walks up the directory tree from the entry file to the workspace root, using the nearest `package.json` with a valid version. It also handles malformed files and missing versions gracefully, with warnings as appropriate.
* The shared mapping info construction has been centralized in the new `toSharedMappingInfo` function, ensuring consistent handling of versioning and related flags. [[1]](diffhunk://#diff-f875220df9c66a79af76b3171ec94582616092ddedf8fc8041a8a2eca8516597L96-R98) [[2]](diffhunk://#diff-f875220df9c66a79af76b3171ec94582616092ddedf8fc8041a8a2eca8516597L191-L219)

**Testing and reliability:**

* Comprehensive unit tests for `getMappingVersion` have been added, covering edge cases such as missing, malformed, or misplaced `package.json` files, and ensuring the function does not traverse above the workspace root.