### PR TITLE
chore: Added extra options to contracts

### DIFF
--- a/packages/core/src/lib/config/with-native-federation.ts
+++ b/packages/core/src/lib/config/with-native-federation.ts
@@ -1,6 +1,7 @@
 import { getRawMappedPaths } from '../utils/mapped-paths.js';
 import { shareAll, findRootTsConfigJson } from './share-utils.js';
 import type {
+  ExposeEntry,
   FederationConfig,
   NormalizedFederationConfig,
 } from '../domain/config/federation-config.contract.js';
@@ -21,7 +22,7 @@ export function withNativeFederation(config: FederationConfig): NormalizedFedera
   const normalized: NormalizedFederationConfig = {
     $type: 'classic',
     name: config.name ?? '',
-    exposes: config.exposes ?? {},
+    exposes: normalizeExposes(config.exposes),
     shared: normalizeShared(config, skip, chunks),
     sharedMappings: removeSkippedMappings(config, skip),
     chunks,
@@ -37,6 +38,18 @@ export function withNativeFederation(config: FederationConfig): NormalizedFedera
   };
 
   return normalized;
+}
+
+function normalizeExposes(
+  exposes: FederationConfig['exposes']
+): Record<string, ExposeEntry> {
+  if (!exposes) return {};
+  return Object.fromEntries(
+    Object.entries(exposes).map(([key, value]) => [
+      key,
+      typeof value === 'string' ? { file: value } : value,
+    ])
+  );
 }
 
 function normalizeShared(

--- a/packages/core/src/lib/core/bundle-exposed-and-mappings.ts
+++ b/packages/core/src/lib/core/bundle-exposed-and-mappings.ts
@@ -39,10 +39,12 @@ export async function bundleExposedAndMappings(
       };
     }
   );
-  const exposes: EntryPoint[] = Object.entries(config.exposes).map(([key, entry]) => {
-    const outFilePath = key + '.js';
-    return { fileName: entry, outName: outFilePath, key };
-  });
+  const exposes: Array<EntryPoint & { element?: string }> = Object.entries(config.exposes).map(
+    ([key, expose]) => {
+      const outFilePath = key + '.js';
+      return { fileName: expose.file, outName: outFilePath, key, element: expose.element };
+    }
+  );
 
   const entryPoints: EntryPoint[] = [...shared, ...exposes];
 
@@ -108,6 +110,7 @@ export async function bundleExposedAndMappings(
     exposedResult.push({
       key: item.key!,
       outFileName: path.basename(distEntryFile),
+      ...(item.element && { element: item.element }),
       dev: !fedOptions.dev
         ? undefined
         : {
@@ -153,13 +156,15 @@ export function describeExposed(
   const result: Array<ExposesInfo> = [];
 
   for (const key in config.exposes) {
+    const expose = config.exposes[key]!;
     const localPath = normalize(
-      path.normalize(path.join(options.workspaceRoot, config.exposes[key]!))
+      path.normalize(path.join(options.workspaceRoot, expose.file))
     );
 
     result.push({
       key,
       outFileName: '',
+      ...(expose.element && { element: expose.element }),
       dev: !options.dev
         ? undefined
         : {

--- a/packages/core/src/lib/core/normalize-options.ts
+++ b/packages/core/src/lib/core/normalize-options.ts
@@ -56,7 +56,7 @@ export async function normalizeFederationOptions<TBundlerCache = undefined>(
 
   const normalizedOptions: NormalizedFederationOptions<TBundlerCache> = {
     ...options,
-    entryPoints: options.entryPoints ?? Object.values(config.exposes ?? {}),
+    entryPoints: options.entryPoints ?? Object.values(config.exposes ?? {}).map(e => e.file),
     projectName: resolveProjectName(options.projectName ?? config.name),
     cacheExternalArtifacts: options.cacheExternalArtifacts ?? true,
     federationCache,

--- a/packages/core/src/lib/domain/config/federation-config.contract.ts
+++ b/packages/core/src/lib/domain/config/federation-config.contract.ts
@@ -5,9 +5,11 @@ import type {
   SharedExternalsConfig,
 } from './external-config.contract.js';
 
+export type ExposeEntry = { file: string; element?: string };
+
 export interface FederationConfig {
   name?: string;
-  exposes?: Record<string, string>;
+  exposes?: Record<string, string | ExposeEntry>;
   shared?: SharedExternalsConfig;
   platform?: 'browser' | 'node';
   sharedMappings?: Array<string>;
@@ -26,7 +28,7 @@ export interface FederationConfig {
 export interface NormalizedFederationConfig {
   $type: 'classic';
   name: string;
-  exposes: Record<string, string>;
+  exposes: Record<string, ExposeEntry>;
   shared: NormalizedSharedExternalsConfig;
   sharedMappings: PathToImport;
   skip: PreparedSkipList;

--- a/packages/core/src/lib/domain/core/federation-info.contract.ts
+++ b/packages/core/src/lib/domain/core/federation-info.contract.ts
@@ -6,6 +6,7 @@ export interface FederationInfo {
   integrity?: IntegrityMap;
   buildNotificationsEndpoint?: string;
 }
+
 export type SharedInfo = {
   singleton: boolean;
   strictVersion: boolean;
@@ -27,6 +28,7 @@ export type IntegrityMap = Record<string, string>;
 export interface ExposesInfo {
   key: string;
   outFileName: string;
+  element?: string;
   dev?: {
     entryPoint: string;
   };

--- a/packages/core/src/lib/domain/core/index.ts
+++ b/packages/core/src/lib/domain/core/index.ts
@@ -23,3 +23,4 @@ export type {
 } from './build-adapter.contract.js';
 export { CHUNK_PREFIX, toChunkImport } from './chunk.js';
 export type { FederationCache } from './federation-cache.contract.js';
+export type { FederationManifest } from './manifest.contract.js';

--- a/packages/core/src/lib/domain/core/manifest.contract.ts
+++ b/packages/core/src/lib/domain/core/manifest.contract.ts
@@ -1,0 +1,4 @@
+export type FederationManifest = Record<
+  string,
+  string | { url: string; integrity?: string; main?: string }
+>;

--- a/packages/core/src/lib/utils/get-used-dependencies.ts
+++ b/packages/core/src/lib/utils/get-used-dependencies.ts
@@ -4,6 +4,7 @@ import { getPackageInfo } from './package-info.js';
 import { getExternalImports as extractExternalImports } from './get-external-imports.js';
 import { type PathToImport } from '../domain/utils/mapped-path.contract.js';
 import { type UsedDependencies } from '../domain/utils/used-dependencies.contract.js';
+import { type ExposeEntry } from '../domain/config/federation-config.contract.js';
 import * as path from 'path';
 
 export function getUsedDependenciesFactory(
@@ -11,11 +12,11 @@ export function getUsedDependenciesFactory(
   fallbackEntryPoints?: string[]
 ): (config: {
   name?: string;
-  exposes?: Record<string, string>;
+  exposes?: Record<string, ExposeEntry>;
   sharedMappings: PathToImport;
 }) => UsedDependencies {
   return config => {
-    let entryPoints: string[] | undefined = Object.values(config.exposes ?? {});
+    let entryPoints: string[] | undefined = Object.values(config.exposes ?? {}).map(e => e.file);
     if (entryPoints.length < 1) entryPoints = fallbackEntryPoints;
 
     if (!entryPoints || entryPoints.length < 1)


### PR DESCRIPTION
Connected to https://github.com/native-federation/orchestrator/issues/14

This pull request refactors how the `exposes` property is handled in the federation configuration, enabling richer metadata for each exposed entry. The main change is moving from a simple string mapping to an object-based structure, which allows each expose to specify additional properties such as `element`. The changes are implemented across type definitions, normalization logic, and all usages of `exposes` throughout the codebase.

**Key changes include:**

### Federation Configuration and Typing

* Updated the `exposes` property in `FederationConfig` and `NormalizedFederationConfig` to support both string and object entries, introducing the `ExposeEntry` type with optional `element` metadata. [[1]](diffhunk://#diff-ab1de0fd20adbe81d58abca8127d6c7fe39501f5a6819bb04e1baeb0b6fb9130R8-R12) [[2]](diffhunk://#diff-ab1de0fd20adbe81d58abca8127d6c7fe39501f5a6819bb04e1baeb0b6fb9130L29-R31)
* Adjusted all relevant type usages and function signatures to use the new `ExposeEntry` structure. [[1]](diffhunk://#diff-ea9862820a468860ef278e65e8b9a0e59229698544f293fc5828f465089cb44aR7-R19) [[2]](diffhunk://#diff-de670b3bef243bc4006a67d5388c74a669bc5b0a1043c0112142454ca8111151R31)

### Normalization and Utility Functions

* Added a `normalizeExposes` function to consistently convert string exposes to the new object format and applied it in the federation normalization logic. [[1]](diffhunk://#diff-319207b5f23e1cad4b1bf54fe0ba8da92f1409ca1fb094fa57b4247123644b1bR4) [[2]](diffhunk://#diff-319207b5f23e1cad4b1bf54fe0ba8da92f1409ca1fb094fa57b4247123644b1bL24-R25) [[3]](diffhunk://#diff-319207b5f23e1cad4b1bf54fe0ba8da92f1409ca1fb094fa57b4247123644b1bR43-R54)
* Updated utility functions and factories (e.g., `getUsedDependenciesFactory`, `normalizeFederationOptions`) to extract file paths from the new object format. [[1]](diffhunk://#diff-ea9862820a468860ef278e65e8b9a0e59229698544f293fc5828f465089cb44aR7-R19) [[2]](diffhunk://#diff-19dcae6cc132c822b531faa9bb908c35cd34aa81ee98e851fa4a0c8a2f716bacL59-R59)

### Core Logic and Data Structures

* Refactored the logic in `bundleExposedAndMappings` and related functions to handle the new `ExposeEntry` structure, ensuring `element` metadata is preserved and propagated in outputs. [[1]](diffhunk://#diff-f875220df9c66a79af76b3171ec94582616092ddedf8fc8041a8a2eca8516597L42-R47) [[2]](diffhunk://#diff-f875220df9c66a79af76b3171ec94582616092ddedf8fc8041a8a2eca8516597R113) [[3]](diffhunk://#diff-f875220df9c66a79af76b3171ec94582616092ddedf8fc8041a8a2eca8516597R159-R167)

### Manifest Typing

* Introduced a new `FederationManifest` type for representing federation manifests, supporting both string and object entries with metadata. [[1]](diffhunk://#diff-2c841760f3a50c817f73b449d97755ddc5fc3bbf020d9115fb1e46cd605be4e9R26) [[2]](diffhunk://#diff-1a68339cad75deca32d93068b6368b0d24eb2dadd29f8c7a6421564f9e3821efR1-R4)