### PR TITLE
fix: issue where not all folders were generated during a build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v2
         with:
-          version: 10
+          version: 11
 
       - uses: actions/setup-node@v4
         with:

--- a/packages/core/src/lib/utils/cache-persistence.ts
+++ b/packages/core/src/lib/utils/cache-persistence.ts
@@ -65,7 +65,7 @@ export const cacheEntry = (pathToCache: string, fileName: string) => ({
       files: string[];
     } = JSON.parse(fs.readFileSync(metadataFile, 'utf-8'));
 
-    fs.mkdirSync(path.dirname(fullOutputPath), { recursive: true });
+    fs.mkdirSync(fullOutputPath, { recursive: true });
 
     cachedResult.files.forEach(file => {
       const cachedFile = path.join(pathToCache, file);

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,8 @@ packages:
   - packages/core
   - packages/runtime
   - packages/node
+allowBuilds:
+  '@swc/core': true
+  esbuild: true
+  msw: false
+  nx: false


### PR DESCRIPTION
Closes #51

This pull request introduces a few targeted updates to the project’s build configuration and caching utilities. The main changes involve updating dependencies, modifying cache directory creation logic, and configuring build permissions for certain packages.

Dependency and build configuration updates:

* Upgraded the `pnpm` version from 10 to 11 in the CI workflow to ensure compatibility with newer features and bug fixes. (.github/workflows/ci.yml)
* Added an `allowBuilds` section to `pnpm-workspace.yaml` to explicitly allow or disallow builds for specific dependencies such as `@swc/core`, `esbuild`, `msw`, and `nx`. (pnpm-workspace.yaml)

Cache utility fix:

* Changed the cache persistence utility to create the full output path as a directory rather than just its parent, which may address issues where the expected directory structure was not present. (packages/core/src/lib/utils/cache-persistence.ts)