### PR TITLE
fix: Added some security hardening for config

### DIFF
--- a/src/lib/config/share-utils.ts
+++ b/src/lib/config/share-utils.ts
@@ -2,7 +2,12 @@ import * as path from 'path';
 import { cwd } from 'process';
 import { DEFAULT_SKIP_LIST, isInSkipList, prepareSkipList } from './default-skip-list.js';
 import { type SkipList, type PreparedSkipList } from '../domain/config/skip-list.contract.js';
-import { sharedPackageJsonRepository, findDepPackageJson, getVersionMaps, type VersionMap } from '../utils/package/package-info.js';
+import {
+  sharedPackageJsonRepository,
+  findDepPackageJson,
+  getVersionMaps,
+  type VersionMap,
+} from '../utils/package/package-info.js';
 import type { PackageJsonRepository } from '../domain/utils/package-json.contract.js';
 import { getConfigContext } from './configuration-context.js';
 import { logger } from '../utils/logger.js';
@@ -144,11 +149,14 @@ export function getSecondaries(
 
   let resolveGlob = false;
   if (typeof includeSecondaries === 'object') {
-    if (Array.isArray(includeSecondaries.skip)) {
-      exclude = includeSecondaries.skip;
-    } else if (typeof includeSecondaries.skip === 'string') {
-      exclude = [includeSecondaries.skip];
+    if (includeSecondaries.skip) {
+      if (Array.isArray(includeSecondaries.skip)) {
+        exclude = includeSecondaries.skip;
+      } else if (typeof includeSecondaries.skip === 'string') {
+        exclude = [includeSecondaries.skip];
+      }
     }
+
     resolveGlob = !!includeSecondaries.resolveGlob;
   }
 
@@ -444,7 +452,7 @@ export function shareCore(
     if (
       shareObject.requiredVersion === 'auto' ||
       (inferVersion && typeof shareObject.requiredVersion === 'undefined') ||
-      shareObject.requiredVersion.length < 1
+      shareObject.requiredVersion?.length < 1
     ) {
       const version = lookupVersion(key, projectPath, repo);
 

--- a/src/lib/domain/config/external-config.contract.ts
+++ b/src/lib/domain/config/external-config.contract.ts
@@ -33,14 +33,14 @@ export interface NormalizedExternalConfig {
 }
 
 export type IncludeSecondariesOptions =
-  | { skip: string | string[]; resolveGlob?: boolean; keepAll?: boolean }
+  | { skip?: string | string[]; resolveGlob?: boolean; keepAll?: boolean }
   | boolean;
 
 export type SharedExternalsConfig = Record<string, ExternalConfig>;
 
 export type NormalizedSharedExternalsConfig = Record<string, NormalizedExternalConfig>;
 
-export type ShareAllExternalsOptions = ExternalConfig & {
+export type ShareAllExternalsOptions = Omit<ExternalConfig, 'includeSecondaries'> & {
   includeSecondaries?: IncludeSecondariesOptions;
 };
 


### PR DESCRIPTION
Closes #64 

This pull request makes several improvements to the handling of secondary package inclusion and external configuration types in the codebase. The main changes include making the `skip` property in `IncludeSecondariesOptions` optional, updating logic to handle this new optionality, and refining type definitions for shared external configuration. These updates improve flexibility and type safety when configuring shared dependencies.

**Type definition improvements:**

* Made the `skip` property in the `IncludeSecondariesOptions` type optional, allowing consumers to omit it when not needed.
* Updated the `ShareAllExternalsOptions` type to use `Omit<ExternalConfig, 'includeSecondaries'>`, ensuring that `includeSecondaries` is only present as an optional property.

**Logic updates for optional skip:**

* Updated the `getSecondaries` function to check for the presence of `skip` before accessing it, ensuring correct handling when `skip` is not provided.

**Code quality and robustness:**

* Updated the condition in `shareCore` to safely check the length of `requiredVersion` only if it is defined, preventing potential runtime errors.

**Code style:**

* Reformatted the import statement from `package-info.js` for improved readability and consistency.

**External:**

* To fully fix the issue, another fix in the angular adapter is also necessary. 