### PR TITLE
fix: content-hash shared entry filenames to prevent stale-cache chunk…

### DIFF
--- a/src/lib/core/build/bundle-shared.spec.ts
+++ b/src/lib/core/build/bundle-shared.spec.ts
@@ -7,6 +7,8 @@ import { createMemoryIo } from '../../utils/io/__test-helpers__/memory-io.js';
 import { createFakeBuildAdapter } from './__test-helpers__/fake-build-adapter.js';
 import { prepareSkipList } from '../../config/default-skip-list.js';
 import type { PackageJsonRepository } from '../../domain/utils/package-json.contract.js';
+import type { IoPort } from '../../domain/utils/io-port.contract.js';
+import type { NFBuildAdapter } from '../../domain/core/build-adapter.contract.js';
 import type { NormalizedExternalConfig } from '../../domain/config/external-config.contract.js';
 import type { NormalizedFederationConfig } from '../../domain/config/federation-config.contract.js';
 import type { NormalizedFederationOptions } from '../../domain/core/federation-options.contract.js';
@@ -164,5 +166,57 @@ describe('bundleSharedCore (via injected io, repo and build adapter)', () => {
 
     expect(result.externals).toHaveLength(1);
     expect(result.externals[0]).toMatchObject({ packageName: 'foo', version: '2.0.0' });
+  });
+
+  it('names a shared entry by its content, so the name changes when the bundle changes', async () => {
+    const sharedBundles: Record<string, NormalizedExternalConfig> = {
+      foo: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+        version: '1.0.0',
+        chunks: false,
+        platform: 'browser',
+        build: 'default',
+        packageInfo: { entryPoint: 'foo/index.js', version: '1.0.0', esm: true },
+      },
+    };
+
+    // Adapter that writes a given body as the entry's bundled content.
+    const writingAdapter = (io: IoPort, body: string): NFBuildAdapter => {
+      let outdir = '';
+      let outName = '';
+      return {
+        async setup(_name, opts) {
+          outdir = opts.outdir;
+          outName = opts.entryPoints[0]!.outName;
+        },
+        async build() {
+          io.writeText(path.join(outdir, outName), body);
+          return [{ fileName: path.join(outdir, outName) }];
+        },
+        async dispose() {},
+      };
+    };
+
+    const build = async (body: string) => {
+      const mem = createMemoryIo().setFile(ROOT_PKG, '{}');
+      const result = await bundleSharedCore(
+        { io: mem, repo: emptyRepo, adapter: writingAdapter(mem, body) },
+        sharedBundles,
+        makeConfig(),
+        makeFedOptions(),
+        [],
+        BUILD_OPTIONS
+      );
+      return result.externals[0]!.outFileName;
+    };
+
+    const a = await build('export const x = 1;\n');
+    const b = await build('export const x = 2;\n');
+
+    expect(a).toMatch(/^foo\..{10}\.js$/);
+    expect(a).toBe(await build('export const x = 1;\n')); // stable for identical content
+    expect(a).not.toBe(b); // changes when content changes
   });
 });

--- a/src/lib/core/build/bundle-shared.ts
+++ b/src/lib/core/build/bundle-shared.ts
@@ -12,7 +12,7 @@ import { type NormalizedFederationOptions } from '../../domain/core/federation-o
 import { logger } from '../../utils/logger.js';
 import { nodeIo } from '../../utils/io/node-io-adapter.js';
 import { DEFAULT_EXTERNAL_LIST } from './default-external-list.js';
-import { isSourceFile, rewriteChunkImportsCore } from './rewrite-chunk-imports.js';
+import { isSourceFile, transformChunkImports } from './rewrite-chunk-imports.js';
 import { toChunkImport } from '../../domain/core/chunk.js';
 import { cacheEntryCore, getChecksumCore, getFilename } from '../cache/cache-persistence.js';
 import { computeIntegrityMapCore } from './compute-integrity.js';
@@ -128,7 +128,6 @@ export async function bundleSharedCore(
 
   const fullOutputPath = path.join(fedOptions.workspaceRoot, fedOptions.outputPath);
 
-  const expectedResults = allEntryPoints.map(ep => path.join(fullOutputPath, ep.outName));
   const entryPoints = allEntryPoints.filter(
     ep => !deps.io.exists(path.join(fedOptions.federationCache.cachePath, ep.outName))
   );
@@ -163,7 +162,18 @@ export async function bundleSharedCore(
     await deps.adapter.dispose(buildOptions.bundleName);
 
     const cachedFiles = bundleResult.map(br => path.basename(br.fileName));
-    rewriteImports(deps.io, cachedFiles, fedOptions.federationCache.cachePath);
+    // Re-key entry files (version-based names) to a hash of their final content, so a
+    // changed bundle always gets a new name and never reuses a stale cached one.
+    const hashEntries = fedOptions.dev
+      ? new Set<string>()
+      : new Set(allEntryPoints.map(ep => ep.outName));
+    const renamed = rewriteImports(
+      deps.io,
+      cachedFiles,
+      fedOptions.federationCache.cachePath,
+      hashEntries
+    );
+    applyRenames(bundleResult, allEntryPoints, renamed);
   } catch (e) {
     logger.error('Error bundling shared npm package ');
     if (e instanceof Error) {
@@ -192,7 +202,7 @@ export async function bundleSharedCore(
     throw e;
   }
 
-  const outFileNames = [...expectedResults];
+  const outFileNames = allEntryPoints.map(ep => path.join(fullOutputPath, ep.outName));
 
   const result = buildResult(packageInfos, sharedBundles, outFileNames);
 
@@ -237,12 +247,46 @@ export async function bundleSharedCore(
   return { externals: result, chunks: exportedChunks, integrity };
 }
 
-function rewriteImports(io: IoPort, cachedFiles: string[], cachePath: string) {
-  const newSourceFiles = cachedFiles.filter(cf => isSourceFile(cf));
+function rewriteImports(
+  io: IoPort,
+  cachedFiles: string[],
+  cachePath: string,
+  hashEntries: Set<string>
+): Map<string, string> {
+  const renamed = new Map<string, string>();
 
-  for (const sourceFile of newSourceFiles) {
-    const sourceFilePath = path.join(cachePath, sourceFile);
-    rewriteChunkImportsCore(io, sourceFilePath);
+  for (const file of cachedFiles.filter(isSourceFile)) {
+    const filePath = path.join(cachePath, file);
+    const rewritten = transformChunkImports(io.readText(filePath), file);
+
+    if (hashEntries.has(file)) {
+      const hashedName = `${file.split('.')[0]}.${calcHashCore(io, rewritten)}.js`;
+      io.writeText(path.join(cachePath, hashedName), rewritten);
+      io.remove(filePath);
+      renamed.set(file, hashedName);
+    } else {
+      io.writeText(filePath, rewritten);
+    }
+  }
+
+  return renamed;
+}
+
+function applyRenames(
+  bundleResult: NFBuildAdapterResult[],
+  allEntryPoints: EntryPoint[],
+  renamed: Map<string, string>
+): void {
+  if (renamed.size === 0) return;
+
+  for (const br of bundleResult) {
+    const next = renamed.get(path.basename(br.fileName));
+    if (next) br.fileName = path.join(path.dirname(br.fileName), next);
+  }
+
+  for (const ep of allEntryPoints) {
+    const next = renamed.get(ep.outName);
+    if (next) ep.outName = next;
   }
 }
 

--- a/src/lib/core/build/rewrite-chunk-imports.ts
+++ b/src/lib/core/build/rewrite-chunk-imports.ts
@@ -12,10 +12,12 @@ export function rewriteChunkImportsCore(
   io: FileReaderPort & FileWriterPort,
   filePath: string
 ): void {
-  const sourceCode = io.readText(filePath);
+  io.writeText(filePath, transformChunkImports(io.readText(filePath), path.basename(filePath)));
+}
 
+export function transformChunkImports(sourceCode: string, fileName: string): string {
   const sourceFile = ts.createSourceFile(
-    path.basename(filePath),
+    fileName,
     sourceCode,
     ts.ScriptTarget.ESNext,
     true,
@@ -75,9 +77,7 @@ export function rewriteChunkImportsCore(
   const transformed = ts.transform(sourceFile, [_ => node => ts.visitNode(node as any, visit)]);
   const updatedSourceFile = transformed.transformed[0];
 
-  const result = printer.printFile(updatedSourceFile as ts.SourceFile);
-
-  io.writeText(filePath, result);
+  return printer.printFile(updatedSourceFile as ts.SourceFile);
 }
 
 export function isSourceFile(fileName: string): boolean {


### PR DESCRIPTION
## Summary

Shared-package entry files (e.g. `_acme_ui_core_utils.<hash>.js`) are named by `createOutName()`
from the package **version + entry path + config** — not from their emitted content. Their content
is mostly `@nf-internal/chunk-*` imports that resolve, via `remoteEntry.json` / `importmap.json`,
into a code-split chunk graph **shared across all `share()` packages**. When that graph changes
(any shared dep shifts, or a split boundary moves), the chunk content-hash names change
(`chunk-BL4UGAOX` → `chunk-I76J64FX`) and the entry file's body changes — **but its version-based
filename does not**.

A browser/CDN that cached the previous build's entry then serves a file importing a chunk the
always-fresh `remoteEntry.json` no longer lists:

```
Error: Unable to resolve specifier '@nf-internal/chunk-BL4UGAOX'
  imported from .../_acme_ui_core_utils.<hash>.js
```

The package's own version need not change — the drift is driven by *other* shared packages
reshaping the shared chunk graph, so a version bump (or an immutable, registry-locked version) does
not avoid it.

## Change

Entry filenames are re-keyed to a hash of their **final content** (after chunk-import rewriting), so
the name changes if and only if the bundle changes. Chunks are already content-hashed and left
untouched; dev/watch is unaffected (gated to `!fedOptions.dev`).

Concretely:

- Extracted a pure `transformChunkImports(source, fileName)` from `rewrite-chunk-imports.ts`
  (`rewriteChunkImportsCore` is unchanged behaviourally).
- `bundleShared`'s `rewriteImports` now does one read → transform → write per file, and for
  production entries writes the rewritten bytes **directly under the content-hashed name**, then
  removes the bundler's version-named intermediate. `applyRenames` syncs `bundleResult` and
  `allEntryPoints` so `remoteEntry.json`, integrity and `copyFiles` all use the final names.
- Reuses the existing `calcHashCore` (sha256 → base64url → 10 chars); no new hashing primitive.

### Note on "write directly instead of renaming" (review feedback)

The hashing is folded into the write step — there is **no separate post-build rename pass**, and the
final bytes are written once under the content-hashed name. It is not fully rename-free, though:
the injected build adapter writes the entry under the version-based `outName` first, and we
`io.remove()` that intermediate. This is unavoidable in core because (a) the content hash can only
be computed *after* the post-bundle `@nf-internal/*` rewrite, so the final bytes don't exist when
the bundler writes; and (b) the bundler is external/injected, so it owns that first write. The
`remove` is also required so the version-named intermediate can't be picked up by the content-blind
`entryPoints` skip-filter on the next build. Letting the bundler emit `hash: true` names instead
would hash the *pre-rewrite* output and so would not actually fix the bug. Open to alternatives if
preferred (e.g. reworking the skip-filter so the intermediate need not be removed).

## Tests

`bundle-shared.spec.ts` adds a case that builds the same package twice with different bundle content
and asserts the entry filename changes (and is stable for identical content). `tsc --noEmit` passes;
existing tests are unaffected (entry names remain `<encName>.<10>.js`, now content-derived).

## Compatibility

Output filenames for shared packages remain `<encName>.<hash>.js` but the hash is now content-based.
Consumers resolve everything through `remoteEntry.json` / `importmap.json`, which are updated in the
same pass, so no runtime references break.