### PR TITLE
fix: issue where js files were wrongfully skipped

### DIFF
--- a/src/lib/config/share-utils.spec.ts
+++ b/src/lib/config/share-utils.spec.ts
@@ -59,6 +59,39 @@ describe('getSecondaries', () => {
     expect(result!['mylib/sub']).toMatchObject({ singleton: true });
   });
 
+  it('resolves a glob whose pattern has no JS extension and filters non-JS files', () => {
+    const io = createMemoryIo()
+      .setFile(
+        path.join(LIB, 'package.json'),
+        JSON.stringify({
+          version: '1.2.3',
+          type: 'module',
+          exports: {
+            '.': './index.js',
+            './components/*': './components/*',
+          },
+        })
+      )
+      .setFile(path.join(LIB, 'components', 'button.js'), '')
+      .setFile(path.join(LIB, 'components', 'icon.mjs'), '')
+      .setFile(path.join(LIB, 'components', 'styles.css'), '')
+      .setFile(path.join(LIB, 'components', 'logo.svg'), '');
+
+    const result = getSecondaries(
+      io,
+      { skip: [], resolveGlob: true },
+      LIB,
+      'mylib',
+      shareObject,
+      EMPTY_SKIP
+    );
+
+    expect(Object.keys(result!).sort()).toEqual([
+      'mylib/components/button.js',
+      'mylib/components/icon.mjs',
+    ]);
+  });
+
   it('falls back to walking subfolders (readDir) when there is no exports map', () => {
     const io = createMemoryIo()
       .setFile(path.join(LIB, 'sub', 'package.json'), '{}')

--- a/src/lib/config/share-utils.ts
+++ b/src/lib/config/share-utils.ts
@@ -12,9 +12,9 @@ import type { PackageJsonRepository } from '../domain/utils/package-json.contrac
 import { getConfigContext } from './configuration-context.js';
 import { logger } from '../utils/logger.js';
 import { nodeIo } from '../utils/io/node-io-adapter.js';
-import type { FileReaderPort } from '../domain/utils/io-port.contract.js';
+import type { FileReaderPort, GlobPort } from '../domain/utils/io-port.contract.js';
 
-import { resolvePackageJsonExportsWildcard } from '../utils/package/resolve-wildcard-keys.js';
+import { resolvePackageJsonExportsWildcardCore } from '../utils/package/resolve-wildcard-keys.js';
 import type {
   ExternalConfig,
   IncludeSecondariesOptions,
@@ -138,7 +138,7 @@ function findSecondaries(
 }
 
 export function getSecondaries(
-  io: FileReaderPort,
+  io: FileReaderPort & GlobPort,
   includeSecondaries: IncludeSecondariesOptions,
   libPath: string,
   key: string,
@@ -185,7 +185,7 @@ export function getSecondaries(
 }
 
 function readConfiguredSecondaries(
-  io: FileReaderPort,
+  io: FileReaderPort & GlobPort,
   parent: string,
   libPath: string,
   exclude: string[],
@@ -240,11 +240,12 @@ function readConfiguredSecondaries(
       continue;
     }
 
-    if (!entry?.endsWith('.js') && !entry?.endsWith('.mjs') && !entry?.endsWith('.cjs')) {
+    if (!key.includes('*') && !isJsFile(entry)) {
       continue;
     }
 
     const items = resolveGlobSecondaries(
+      io,
       key,
       libPath,
       parent,
@@ -277,6 +278,7 @@ function readConfiguredSecondaries(
 }
 
 function resolveGlobSecondaries(
+  io: GlobPort,
   key: string,
   libPath: string,
   parent: string,
@@ -288,13 +290,16 @@ function resolveGlobSecondaries(
   let items: Array<string | KeyValuePair> = [];
   if (key.includes('*')) {
     if (!resolveGlob) return items;
-    const expanded = resolvePackageJsonExportsWildcard(key, entry, libPath);
+    const expanded = resolvePackageJsonExportsWildcardCore(io, key, entry, libPath);
     items = expanded
       .map(e => ({
         key: path.join(parent, e.key),
         value: path.join(libPath, e.value),
       }))
       .filter(i => {
+        if (!isJsFile(i.value)) {
+          return false;
+        }
         if (
           excludes.skip.some(e =>
             e.endsWith('*') ? i.key.startsWith(e.slice(0, -1)) : e === i.key
@@ -311,6 +316,10 @@ function resolveGlobSecondaries(
     items = [secondaryName];
   }
   return items;
+}
+
+function isJsFile(file: string): boolean {
+  return file.endsWith('.js') || file.endsWith('.mjs') || file.endsWith('.cjs');
 }
 
 function getDefaultEntry(exports: Record<string, Record<string, string>>, key: string) {
@@ -355,7 +364,7 @@ export function shareAll(
 }
 
 export function shareAllCore(
-  io: FileReaderPort,
+  io: FileReaderPort & GlobPort,
   config: ShareAllExternalsOptions,
   opts: {
     skipList?: SkipList;
@@ -429,7 +438,7 @@ export function share(
 }
 
 export function shareCore(
-  io: FileReaderPort,
+  io: FileReaderPort & GlobPort,
   configuredShareObjects: ShareExternalsOptions,
   projectPath = '',
   skipList = DEFAULT_SKIP_LIST,

--- a/src/lib/utils/package/resolve-wildcard-keys.ts
+++ b/src/lib/utils/package/resolve-wildcard-keys.ts
@@ -1,25 +1,6 @@
-import { nodeIo } from '../io/node-io-adapter.js';
 import type { GlobPort } from '../../domain/utils/io-port.contract.js';
 import type { KeyValuePair } from '../../domain/utils/keyvaluepair.contract.js';
 import { captureWildcard, parseWildcard, substituteWildcard, toPosix } from '../path-patterns.js';
-
-/**
- * Resolves package.json exports wildcard patterns.
- *
- * In package.json exports, patterns like `./features/*.js` → `./src/features/*.js` work as follows:
- * - The `*` is a literal string replacement that can include path separators
- * - Importing `pkg/features/a/b.js` captures `a/b` and replaces `*` → `./src/features/a/b.js`
- * - This matches actual files, not directories
- *
- * @see https://nodejs.org/api/packages.html#subpath-patterns
- */
-export function resolvePackageJsonExportsWildcard(
-  keyPattern: string,
-  valuePattern: string,
-  cwd: string
-): KeyValuePair[] {
-  return resolvePackageJsonExportsWildcardCore(nodeIo, keyPattern, valuePattern, cwd);
-}
 
 export function resolvePackageJsonExportsWildcardCore(
   io: GlobPort,


### PR DESCRIPTION
Closes #65 

This pull request improves the handling of package export wildcards and secondary entrypoints in the module sharing utilities. The main focus is on ensuring that only JavaScript files are included when resolving glob patterns in package exports, and on refactoring the code to make the IO interface requirements explicit. Additionally, the test suite has been updated to verify the new filtering behavior.

**Enhancements to secondary entrypoint resolution:**

* Updated the `getSecondaries`, `readConfiguredSecondaries`, `shareAllCore`, and `shareCore` functions to require an IO object that implements both `FileReaderPort` and `GlobPort`, making their dependencies explicit and enabling glob resolution. [[1]](diffhunk://#diff-3083afbbcd6e216158616cad616a57464ddd31f539ec4ca68663b68571136256L141-R141) [[2]](diffhunk://#diff-3083afbbcd6e216158616cad616a57464ddd31f539ec4ca68663b68571136256L188-R188) [[3]](diffhunk://#diff-3083afbbcd6e216158616cad616a57464ddd31f539ec4ca68663b68571136256L358-R367) [[4]](diffhunk://#diff-3083afbbcd6e216158616cad616a57464ddd31f539ec4ca68663b68571136256L432-R441)
* Modified the logic in `readConfiguredSecondaries` and `resolveGlobSecondaries` to filter out non-JS files (only `.js`, `.mjs`, `.cjs` are allowed) when resolving wildcard exports, using a new `isJsFile` helper function. [[1]](diffhunk://#diff-3083afbbcd6e216158616cad616a57464ddd31f539ec4ca68663b68571136256L243-R248) [[2]](diffhunk://#diff-3083afbbcd6e216158616cad616a57464ddd31f539ec4ca68663b68571136256L291-R302) [[3]](diffhunk://#diff-3083afbbcd6e216158616cad616a57464ddd31f539ec4ca68663b68571136256R321-R324)

**Refactoring and interface changes:**

* Refactored `resolvePackageJsonExportsWildcard` in `resolve-wildcard-keys.ts` to require an explicit `GlobPort` IO parameter, removing its dependency on the default `nodeIo` and simplifying its API.

**Test improvements:**

* Added a new test case in `share-utils.spec.ts` to verify that only JS files are included when resolving a glob pattern without a JS extension, ensuring non-JS files are filtered out as intended.