### PR TITLE
chore(#67): Removed dead cache checks

### DIFF
--- a/src/lib/core/build/build-for-federation.ts
+++ b/src/lib/core/build/build-for-federation.ts
@@ -36,88 +36,81 @@ export async function buildForFederation(
   logger.notice("Skip packages you don't want to share in your federation config");
 
   // 2. Externals
-  if (fedOptions.federationCache.externals.length > 0) {
-    logger.info('Checksum matched, re-using cached externals.');
-  }
+  const { sharedBrowser, sharedServer, separateBrowser, separateServer } = splitShared(
+    config.shared
+  );
 
-  if (fedOptions.federationCache.externals.length === 0) {
-    const { sharedBrowser, sharedServer, separateBrowser, separateServer } = splitShared(
-      config.shared
+  if (Object.keys(sharedBrowser).length > 0) {
+    logger.info(`Bundling external npm packages with bundle type 'browser-shared'`);
+    const start = process.hrtime();
+
+    const sharedPackageInfoBrowser = await bundleShared(
+      sharedBrowser,
+      config,
+      fedOptions,
+      externals,
+      { platform: 'browser', bundleName: 'browser-shared', chunks: config.chunks }
     );
 
-    if (Object.keys(sharedBrowser).length > 0) {
-      logger.info(`Bundling external npm packages with bundle type 'browser-shared'`);
-      const start = process.hrtime();
+    logger.measure(start, 'Step 2.1) Bundling all shared browser externals');
 
-      const sharedPackageInfoBrowser = await bundleShared(
-        sharedBrowser,
-        config,
-        fedOptions,
-        externals,
-        { platform: 'browser', bundleName: 'browser-shared', chunks: config.chunks }
-      );
+    addExternalsToCache(fedOptions.federationCache, sharedPackageInfoBrowser);
 
-      logger.measure(start, 'Step 2.1) Bundling all shared browser externals');
-
-      addExternalsToCache(fedOptions.federationCache, sharedPackageInfoBrowser);
-
-      if (signal?.aborted)
-        throw new AbortedError('[buildForFederation] After shared-browser bundle');
-    }
-
-    if (Object.keys(sharedServer).length > 0) {
-      logger.info(`Bundling external npm packages with bundle type 'server-shared'`);
-      const start = process.hrtime();
-
-      const sharedPackageInfoServer = await bundleShared(
-        sharedServer,
-        config,
-        fedOptions,
-        externals,
-        { platform: 'node', bundleName: 'node-shared', chunks: config.chunks }
-      );
-      logger.measure(start, 'Step 2.1) Bundling all shared node externals');
-
-      addExternalsToCache(fedOptions.federationCache, sharedPackageInfoServer);
-
-      if (signal?.aborted) throw new AbortedError('[buildForFederation] After shared-node bundle');
-    }
-
-    if (Object.keys(separateBrowser).length > 0) {
-      logger.info(`Bundling external npm packages with bundle type 'browser-separate'`);
-
-      const start = process.hrtime();
-      const separatePackageInfoBrowser = await bundleSeparatePackages(
-        separateBrowser,
-        externals,
-        config,
-        fedOptions,
-        { platform: 'browser' }
-      );
-      logger.measure(start, 'Step 2.2) Bundling all separate browser external packages');
-      addExternalsToCache(fedOptions.federationCache, separatePackageInfoBrowser);
-      if (signal?.aborted)
-        throw new AbortedError('[buildForFederation] After separate-browser bundle');
-    }
-
-    if (Object.keys(separateServer).length > 0) {
-      logger.info(`Bundling external npm packages with bundle type 'node-separate'`);
-
-      const start = process.hrtime();
-      const separatePackageInfoServer = await bundleSeparatePackages(
-        separateServer,
-        externals,
-        config,
-        fedOptions,
-        { platform: 'node' }
-      );
-
-      logger.measure(start, 'Step 2.2) Bundling all separate node external packages');
-      addExternalsToCache(fedOptions.federationCache, separatePackageInfoServer);
-    }
-
-    if (signal?.aborted) throw new AbortedError('[buildForFederation] After separate-node bundle');
+    if (signal?.aborted) throw new AbortedError('[buildForFederation] After shared-browser bundle');
   }
+
+  if (Object.keys(sharedServer).length > 0) {
+    logger.info(`Bundling external npm packages with bundle type 'server-shared'`);
+    const start = process.hrtime();
+
+    const sharedPackageInfoServer = await bundleShared(
+      sharedServer,
+      config,
+      fedOptions,
+      externals,
+      { platform: 'node', bundleName: 'node-shared', chunks: config.chunks }
+    );
+    logger.measure(start, 'Step 2.1) Bundling all shared node externals');
+
+    addExternalsToCache(fedOptions.federationCache, sharedPackageInfoServer);
+
+    if (signal?.aborted) throw new AbortedError('[buildForFederation] After shared-node bundle');
+  }
+
+  if (Object.keys(separateBrowser).length > 0) {
+    logger.info(`Bundling external npm packages with bundle type 'browser-separate'`);
+
+    const start = process.hrtime();
+    const separatePackageInfoBrowser = await bundleSeparatePackages(
+      separateBrowser,
+      externals,
+      config,
+      fedOptions,
+      { platform: 'browser' }
+    );
+    logger.measure(start, 'Step 2.2) Bundling all separate browser external packages');
+    addExternalsToCache(fedOptions.federationCache, separatePackageInfoBrowser);
+    if (signal?.aborted)
+      throw new AbortedError('[buildForFederation] After separate-browser bundle');
+  }
+
+  if (Object.keys(separateServer).length > 0) {
+    logger.info(`Bundling external npm packages with bundle type 'node-separate'`);
+
+    const start = process.hrtime();
+    const separatePackageInfoServer = await bundleSeparatePackages(
+      separateServer,
+      externals,
+      config,
+      fedOptions,
+      { platform: 'node' }
+    );
+
+    logger.measure(start, 'Step 2.2) Bundling all separate node external packages');
+    addExternalsToCache(fedOptions.federationCache, separatePackageInfoServer);
+  }
+
+  if (signal?.aborted) throw new AbortedError('[buildForFederation] After separate-node bundle');
 
   // 2. Shared mappings and exposed modules
   const start = process.hrtime();

--- a/src/lib/core/build/bundle-shared.spec.ts
+++ b/src/lib/core/build/bundle-shared.spec.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest';
 import * as crypto from 'crypto';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { bundleSharedCore, calcHashCore } from './bundle-shared.js';
+import {
+  bundleSharedCore,
+  calcHashCore,
+  parseBuilderVersion,
+  readBuilderPackageJson,
+} from './bundle-shared.js';
 import { createMemoryIo } from '../../utils/io/__test-helpers__/memory-io.js';
 import { createFakeBuildAdapter } from './__test-helpers__/fake-build-adapter.js';
 import { prepareSkipList } from '../../config/default-skip-list.js';
@@ -45,8 +50,64 @@ describe('calcHashCore', () => {
   });
 });
 
-// bundle-shared reads the lib's own package.json (../../../package.json relative
-// to the module) for the cache config-state; this spec sits in the same folder.
+describe('readBuilderPackageJson', () => {
+  it('walks up to the nearest package.json regardless of file depth', () => {
+    const mem = createMemoryIo().setFile('/pkg/package.json', '{"version":"9.9.9"}');
+    expect(readBuilderPackageJson(mem, '/pkg/dist/lib/core/build/bundle-shared.js')).toBe(
+      '{"version":"9.9.9"}'
+    );
+  });
+
+  it('returns the closest package.json when several exist on the path', () => {
+    const mem = createMemoryIo()
+      .setFile('/pkg/package.json', '{"version":"1.0.0"}')
+      .setFile('/pkg/dist/package.json', '{"version":"2.0.0"}');
+    expect(readBuilderPackageJson(mem, '/pkg/dist/lib/x.js')).toBe('{"version":"2.0.0"}');
+  });
+
+  it('falls back to "{}" when no package.json is found', () => {
+    const mem = createMemoryIo();
+    expect(readBuilderPackageJson(mem, '/nowhere/lib/x.js')).toBe('{}');
+  });
+
+  it('finds the builder package.json when installed under node_modules', () => {
+    const mem = createMemoryIo().setFile(
+      '/app/node_modules/@softarc/native-federation/package.json',
+      '{"version":"4.1.3"}'
+    );
+    expect(
+      readBuilderPackageJson(
+        mem,
+        '/app/node_modules/@softarc/native-federation/dist/lib/core/build/bundle-shared.js'
+      )
+    ).toBe('{"version":"4.1.3"}');
+  });
+
+  it('does not ascend past node_modules into an unrelated package.json', () => {
+    const mem = createMemoryIo().setFile('/app/package.json', '{"version":"7.7.7"}');
+    expect(
+      readBuilderPackageJson(mem, '/app/node_modules/@softarc/native-federation/dist/lib/x.js')
+    ).toBe('{}');
+  });
+});
+
+describe('parseBuilderVersion', () => {
+  it('extracts the version field', () => {
+    expect(parseBuilderVersion('{"version":"4.1.3"}')).toBe('4.1.3');
+  });
+
+  it('returns "" when version is absent', () => {
+    expect(parseBuilderVersion('{}')).toBe('');
+  });
+
+  it('returns "" on invalid JSON instead of throwing', () => {
+    expect(parseBuilderVersion('')).toBe('');
+    expect(parseBuilderVersion('not json')).toBe('');
+  });
+});
+
+// bundleSharedCore walks up to the nearest package.json; this spec shares its folder, so the
+// walk-up resolves the ROOT_PKG seeded below.
 const ROOT_PKG = path.join(path.dirname(fileURLToPath(import.meta.url)), '../../../package.json');
 
 const BUILD_OPTIONS = { platform: 'browser' as const, bundleName: 'shared', chunks: false };

--- a/src/lib/core/build/bundle-shared.ts
+++ b/src/lib/core/build/bundle-shared.ts
@@ -1,6 +1,10 @@
 import * as path from 'path';
 import type { NormalizedFederationConfig } from '../../domain/config/federation-config.contract.js';
-import { sharedPackageJsonRepository, getPackageInfo, type PackageInfo } from '../../utils/package/package-info.js';
+import {
+  sharedPackageJsonRepository,
+  getPackageInfo,
+  type PackageInfo,
+} from '../../utils/package/package-info.js';
 import type { PackageJsonRepository } from '../../domain/utils/package-json.contract.js';
 import type {
   ChunkInfo,
@@ -64,7 +68,16 @@ export async function bundleSharedCore(
   chunks?: Record<string, string[]>;
   integrity?: IntegrityMap;
 }> {
-  const checksum = getChecksumCore(deps.io, sharedBundles, fedOptions.dev ? '1' : '0');
+  // Walk up to the nearest package.json: the file's depth differs across src/dist/test layouts.
+  const builderPackageJson = readBuilderPackageJson(deps.io, fileURLToPath(import.meta.url));
+  const builderVersion = parseBuilderVersion(builderPackageJson);
+
+  const checksum = getChecksumCore(
+    deps.io,
+    sharedBundles,
+    fedOptions.dev ? '1' : '0',
+    builderVersion
+  );
 
   const folder = fedOptions.packageJson
     ? path.dirname(fedOptions.packageJson)
@@ -79,7 +92,7 @@ export async function bundleSharedCore(
   if (fedOptions?.cacheExternalArtifacts) {
     const cacheMetadata = bundleCache.getMetadata(checksum);
     if (cacheMetadata) {
-      logger.debug(`Checksum of ${buildOptions.bundleName} matched, Skipped artifact bundling`);
+      logger.info(`Checksum of ${buildOptions.bundleName} matched, re-using cached externals.`);
       bundleCache.copyFiles(path.join(fedOptions.workspaceRoot, fedOptions.outputPath));
       let integrity = cacheMetadata.integrity;
       if (config.features.integrityHashes && !integrity) {
@@ -113,24 +126,15 @@ export async function bundleSharedCore(
 
   const packageInfos = [...inferredPackageInfos, ...configuredPackageInfos];
 
-  const __filename = fileURLToPath(import.meta.url);
+  const configState = `BUNDLER_CHUNKS;${builderVersion};${JSON.stringify(config)}`;
 
-  const configState =
-    'BUNDLER_CHUNKS' + // TODO: Replace this with lib version
-    deps.io.readText(path.join(path.dirname(__filename), '../../../package.json')) +
-    JSON.stringify(config);
-
-  const allEntryPoints: EntryPoint[] = packageInfos.map(pi => {
+  const entryPoints: EntryPoint[] = packageInfos.map(pi => {
     const encName = pi.packageName.replace(/[^A-Za-z0-9]/g, '_');
     const outName = createOutName(deps.io, pi, configState, fedOptions, encName);
     return { fileName: pi.entryPoint, outName };
   });
 
   const fullOutputPath = path.join(fedOptions.workspaceRoot, fedOptions.outputPath);
-
-  const entryPoints = allEntryPoints.filter(
-    ep => !deps.io.exists(path.join(fedOptions.federationCache.cachePath, ep.outName))
-  );
 
   // If we build for the browser and don't remote unused deps from the shared config,
   // we need to exclude typical node libs to avoid compilation issues
@@ -166,14 +170,14 @@ export async function bundleSharedCore(
     // changed bundle always gets a new name and never reuses a stale cached one.
     const hashEntries = fedOptions.dev
       ? new Set<string>()
-      : new Set(allEntryPoints.map(ep => ep.outName));
+      : new Set(entryPoints.map(ep => ep.outName));
     const renamed = rewriteImports(
       deps.io,
       cachedFiles,
       fedOptions.federationCache.cachePath,
       hashEntries
     );
-    applyRenames(bundleResult, allEntryPoints, renamed);
+    applyRenames(bundleResult, entryPoints, renamed);
   } catch (e) {
     logger.error('Error bundling shared npm package ');
     if (e instanceof Error) {
@@ -202,7 +206,7 @@ export async function bundleSharedCore(
     throw e;
   }
 
-  const outFileNames = allEntryPoints.map(ep => path.join(fullOutputPath, ep.outName));
+  const outFileNames = entryPoints.map(ep => path.join(fullOutputPath, ep.outName));
 
   const result = buildResult(packageInfos, sharedBundles, outFileNames);
 
@@ -262,6 +266,7 @@ function rewriteImports(
     if (hashEntries.has(file)) {
       const hashedName = `${file.split('.')[0]}.${calcHashCore(io, rewritten)}.js`;
       io.writeText(path.join(cachePath, hashedName), rewritten);
+      // Cache hygiene: drop the version-named intermediate (untracked by metadata, so clear() can't reap it).
       io.remove(filePath);
       renamed.set(file, hashedName);
     } else {
@@ -274,7 +279,7 @@ function rewriteImports(
 
 function applyRenames(
   bundleResult: NFBuildAdapterResult[],
-  allEntryPoints: EntryPoint[],
+  entryPoints: EntryPoint[],
   renamed: Map<string, string>
 ): void {
   if (renamed.size === 0) return;
@@ -284,7 +289,7 @@ function applyRenames(
     if (next) br.fileName = path.join(path.dirname(br.fileName), next);
   }
 
-  for (const ep of allEntryPoints) {
+  for (const ep of entryPoints) {
     const next = renamed.get(ep.outName);
     if (next) ep.outName = next;
   }
@@ -357,6 +362,27 @@ function addChunksToResult(chunks: NFBuildAdapterResult[], result: SharedInfo[])
       //       entryPoint: normalize(fileName),
       //     },
     });
+  }
+}
+
+export function readBuilderPackageJson(io: IoPort, fromFile: string): string {
+  let dir = path.dirname(fromFile);
+  for (;;) {
+    const candidate = path.join(dir, 'package.json');
+    if (io.exists(candidate)) return io.readText(candidate);
+    const parent = path.dirname(dir);
+    // Stop at the package boundary: terminate at the filesystem root, and never ascend past a
+    // node_modules dir into an unrelated (consumer / monorepo-root) package.json.
+    if (parent === dir || path.basename(parent) === 'node_modules') return '{}';
+    dir = parent;
+  }
+}
+
+export function parseBuilderVersion(packageJson: string): string {
+  try {
+    return JSON.parse(packageJson).version ?? '';
+  } catch {
+    return '';
   }
 }
 

--- a/src/lib/core/cache/cache-persistence.spec.ts
+++ b/src/lib/core/cache/cache-persistence.spec.ts
@@ -44,12 +44,19 @@ describe('getChecksumCore', () => {
     );
   });
 
+  it('changes when the builder version changes', () => {
+    const base = { react: ext('18') };
+    expect(getChecksumCore(io, base, '0', '1.0.0')).not.toBe(
+      getChecksumCore(io, base, '0', '1.0.1')
+    );
+  });
+
   it('matches a hand-computed sha256', () => {
     const expected = crypto
       .createHash('sha256')
-      .update('deps:react@18:dev=0')
+      .update('deps:react@18:dev=0:builder=2.0.0')
       .digest('hex');
-    expect(getChecksumCore(io, { react: ext('18') }, '0')).toBe(expected);
+    expect(getChecksumCore(io, { react: ext('18') }, '0', '2.0.0')).toBe(expected);
   });
 });
 

--- a/src/lib/core/cache/cache-persistence.ts
+++ b/src/lib/core/cache/cache-persistence.ts
@@ -23,13 +23,15 @@ export const getFilename = (title: string, dev?: boolean) => {
 
 export const getChecksum = (
   shared: Record<string, NormalizedExternalConfig>,
-  dev: '1' | '0'
-): string => getChecksumCore(nodeIo, shared, dev);
+  dev: '1' | '0',
+  builderVersion = ''
+): string => getChecksumCore(nodeIo, shared, dev, builderVersion);
 
 export const getChecksumCore = (
   hash: HashPort,
   shared: Record<string, NormalizedExternalConfig>,
-  dev: '1' | '0'
+  dev: '1' | '0',
+  builderVersion = ''
 ): string => {
   const denseExternals = Object.keys(shared)
     .sort()
@@ -39,7 +41,7 @@ export const getChecksumCore = (
       );
     }, 'deps');
 
-  return hash.hash('sha256', denseExternals + `:dev=${dev}`).hex();
+  return hash.hash('sha256', denseExternals + `:dev=${dev}:builder=${builderVersion}`).hex();
 };
 
 export type CacheMetadata = {


### PR DESCRIPTION
Linked to #67 

**Removed dead code**
  - Deleted the per-file skip-filter in bundle-shared.ts (defeated by the unconditional bundleCache.clear(), never hit on the watch path, and moot now that the
  version-named intermediate is removed anyway).
  - Removed the always-true in-memory externals guard in build-for-federation.ts (buildForFederation runs at most once per builder; the cache is always created
  empty).

**Fixed/relocated logging**
  - Moved the misleading "Checksum matched, re-using cached externals" log out of the dead branch and into the real Hash A cache-hit site, so it fires per-bundle
  only on a genuine checksum match.

**Tightened cache invalidation (Hash A)**
  - Folded the builder's own package.json version into the checksum (:builder=<version>), so upgrading Native Federation without bumping a shared dep now busts
  the shared-artifact cache. (Deliberately scoped to builder version, not full configState — the federation-config-change-without-dep-bump case is left open as
  low severity.)

**Fixed a latent crash (the most consequential bit)**
  - The builder-version / configState read used a hardcoded ../../../package.json path. After the post-release file restructure (lib/core/build/) this resolved
  to a non-existent dist/package.json at runtime → readFileSync would throw and break the build. Replaced it with readBuilderPackageJson(), which walks up to the
  nearest package.json, stops at the node_modules boundary and filesystem root, and falls back gracefully. Added focused tests.