### PR TITLE
fix(#56): regression of internal builder exports

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -22,5 +22,5 @@ export {
 } from './lib/utils/package/package-info.js';
 export { isInSkipList, prepareSkipList } from './lib/config/default-skip-list.js';
 
-export { NfFileWatcher, NfFileWatcherOptions } from './lib/domain/utils/file-watcher.contract.js';
+export type { NfFileWatcher, NfFileWatcherOptions } from './lib/domain/utils/file-watcher.contract.js';
 export { syncNfFileWatcher, createNfWatcher } from './lib/utils/file-watcher.js';


### PR DESCRIPTION
This pull request makes a minor change to the way `NfFileWatcher` and `NfFileWatcherOptions` are exported from `src/internal.ts`. Instead of exporting them as values, they are now exported as types, which clarifies their intended usage and can help with tree-shaking and type-only imports in TypeScript projects.