### PR TITLE
fix(73): Fixed issue and added temporary extra type

### DIFF
--- a/src/lib/config/share-utils.ts
+++ b/src/lib/config/share-utils.ts
@@ -18,6 +18,7 @@ import { resolvePackageJsonExportsWildcardCore } from '../utils/package/resolve-
 import type {
   ExternalConfig,
   IncludeSecondariesOptions,
+  ResolvedSharedExternalsConfig,
   ShareAllExternalsOptions,
   SharedExternalsConfig,
   ShareExternalsOptions,
@@ -359,7 +360,7 @@ export function shareAll(
     projectPath?: string;
     overrides?: ShareExternalsOptions;
   } = {}
-): ShareExternalsOptions | null {
+): ResolvedSharedExternalsConfig | null {
   return shareAllCore(nodeIo, config, opts);
 }
 
@@ -372,7 +373,7 @@ export function shareAllCore(
     overrides?: ShareExternalsOptions;
   } = {},
   repo: PackageJsonRepository = sharedPackageJsonRepository
-): ShareExternalsOptions | null {
+): ResolvedSharedExternalsConfig | null {
   // let workspacePath: string | undefined = undefined;
   const projectPath = inferProjectPath(opts.projectPath);
 
@@ -433,7 +434,7 @@ export function share(
   configuredShareObjects: ShareExternalsOptions,
   projectPath = '',
   skipList = DEFAULT_SKIP_LIST
-): ShareExternalsOptions {
+): ResolvedSharedExternalsConfig {
   return shareCore(nodeIo, configuredShareObjects, projectPath, skipList);
 }
 
@@ -443,7 +444,7 @@ export function shareCore(
   projectPath = '',
   skipList = DEFAULT_SKIP_LIST,
   repo: PackageJsonRepository = sharedPackageJsonRepository
-): ShareExternalsOptions {
+): ResolvedSharedExternalsConfig {
   projectPath = inferProjectPath(projectPath);
   const packagePath = findPackageJson(io, projectPath);
 

--- a/src/lib/config/with-native-federation.ts
+++ b/src/lib/config/with-native-federation.ts
@@ -85,7 +85,10 @@ function normalizeShared(
       strictVersion: sharedConfig.strictVersion ?? false,
       version: sharedConfig.version,
       chunks: sharedConfig.chunks ?? chunks,
-      includeSecondaries: sharedConfig.includeSecondaries,
+      includeSecondaries:
+        typeof sharedConfig.includeSecondaries === 'object'
+          ? !!sharedConfig.includeSecondaries.keepAll
+          : sharedConfig.includeSecondaries,
       packageInfo: sharedConfig.packageInfo as NormalizedExternalConfig['packageInfo'],
       platform: sharedConfig.platform ?? config.platform ?? 'browser',
       build: sharedConfig.build ?? 'default',

--- a/src/lib/domain/config/external-config.contract.ts
+++ b/src/lib/domain/config/external-config.contract.ts
@@ -1,9 +1,13 @@
+export type IncludeSecondariesOptions =
+  | { skip?: string | string[]; resolveGlob?: boolean; keepAll?: boolean }
+  | boolean;
+
 export interface ExternalConfig {
   singleton?: boolean;
   strictVersion?: boolean;
   requiredVersion?: string;
   version?: string;
-  includeSecondaries?: boolean;
+  includeSecondaries?: IncludeSecondariesOptions;
   platform?: 'browser' | 'node';
   build?: 'separate' | 'package';
   chunks?: boolean;
@@ -32,16 +36,16 @@ export interface NormalizedExternalConfig {
   };
 }
 
-export type IncludeSecondariesOptions =
-  | { skip?: string | string[]; resolveGlob?: boolean; keepAll?: boolean }
-  | boolean;
-
 export type SharedExternalsConfig = Record<string, ExternalConfig>;
 
 export type NormalizedSharedExternalsConfig = Record<string, NormalizedExternalConfig>;
 
-export type ShareAllExternalsOptions = Omit<ExternalConfig, 'includeSecondaries'> & {
-  includeSecondaries?: IncludeSecondariesOptions;
+export type ShareAllExternalsOptions = ExternalConfig;
+
+export type ShareExternalsOptions = SharedExternalsConfig;
+
+export type ResolvedExternalConfig = Omit<ExternalConfig, 'includeSecondaries'> & {
+  includeSecondaries?: boolean;
 };
 
-export type ShareExternalsOptions = Record<string, ShareAllExternalsOptions>;
+export type ResolvedSharedExternalsConfig = Record<string, ResolvedExternalConfig>;

--- a/src/lib/domain/config/index.ts
+++ b/src/lib/domain/config/index.ts
@@ -1,6 +1,8 @@
 export type {
   ExternalConfig,
   IncludeSecondariesOptions,
+  ResolvedExternalConfig,
+  ResolvedSharedExternalsConfig,
   SharedExternalsConfig,
   ShareAllExternalsOptions,
   ShareExternalsOptions,


### PR DESCRIPTION
Closes #73

This pull request refactors the handling of external sharing configuration types in the codebase, with a particular focus on improving type safety and clarity around the `includeSecondaries` option. The changes introduce new resolved config types and update function signatures to use these types, ensuring that downstream consumers receive normalized and predictable config objects.

**Type system improvements and refactoring:**

* Introduced `IncludeSecondariesOptions` as a union type (object or boolean) and updated the `ExternalConfig` interface to use it for the `includeSecondaries` field, allowing for more flexible configuration.
* Added new types: `ResolvedExternalConfig` and `ResolvedSharedExternalsConfig`, representing normalized/processed config objects with `includeSecondaries` always as a boolean, and updated type exports accordingly. [[1]](diffhunk://#diff-8e4e70a21fd9d75320c52c81c4d2eb933c660c8c1636c51f5d950a5f1071a1deL35-R51) [[2]](diffhunk://#diff-d2c6101ec8360b3a3971d67b44f91bee54643cf668a6b4313eff1e43b5f7fdfbR4-R5)
* Updated function signatures in `share-utils.ts` (`shareAll`, `shareAllCore`, `share`, `shareCore`) to return `ResolvedSharedExternalsConfig` instead of the previous, less specific types, enforcing normalized configs throughout the sharing logic. [[1]](diffhunk://#diff-3083afbbcd6e216158616cad616a57464ddd31f539ec4ca68663b68571136256L362-R363) [[2]](diffhunk://#diff-3083afbbcd6e216158616cad616a57464ddd31f539ec4ca68663b68571136256L375-R376) [[3]](diffhunk://#diff-3083afbbcd6e216158616cad616a57464ddd31f539ec4ca68663b68571136256L436-R437) [[4]](diffhunk://#diff-3083afbbcd6e216158616cad616a57464ddd31f539ec4ca68663b68571136256L446-R447) [[5]](diffhunk://#diff-3083afbbcd6e216158616cad616a57464ddd31f539ec4ca68663b68571136256R21)

**Normalization logic:**

* Modified the normalization of `includeSecondaries` in `normalizeShared` to ensure it is always a boolean by checking for the presence of the `keepAll` flag when `includeSecondaries` is an object.

**Follow ups:**

1. Tighten the adapter's share / shareAll return types

Adapter: @angular-architects/native-federation · Requires: core release containing the #73 fix (^<new>)

The adapter's wrappers in `src/config/share-utils.ts` still declare their return as ShareExternalsOptions (the liberal input alias). Now that core's share/shareAll return `ResolvedSharedExternalsConfig` (boolean-only `includeSecondaries`), the wrappers can adopt the same honest type:

```
import type { …, ResolvedSharedExternalsConfig } from '@softarc/native-federation/domain';

export function shareAll(…): ResolvedSharedExternalsConfig | null { … }
export function share(…): ResolvedSharedExternalsConfig { … }
```

Or simply drop the explicit return annotations and let them infer from coreShare/coreShareAll — then the adapter auto-tracks core and can never drift again. Non-breaking; gives adapter users the strict output too.

2. (Future major only) Reconsider the input-type aliases

`ShareAllExternalsOptions` (= `ExternalConfig`) and `ShareExternalsOptions` (= `SharedExternalsConfig`) are now thin aliases. They're accurate and still carry call-shape meaning (single config vs. per-package map), and the adapter + user configs depend on them — so do not deprecate now. If API-surface trimming is ever desired, do it as a deliberate breaking change coordinated with the adapter, not before.