### PR TITLE
fix(74): bad null return  on share and shareAll

### DIFF
--- a/src/lib/config/share-utils.ts
+++ b/src/lib/config/share-utils.ts
@@ -360,7 +360,7 @@ export function shareAll(
     projectPath?: string;
     overrides?: ShareExternalsOptions;
   } = {}
-): ResolvedSharedExternalsConfig | null {
+): ResolvedSharedExternalsConfig {
   return shareAllCore(nodeIo, config, opts);
 }
 
@@ -373,7 +373,7 @@ export function shareAllCore(
     overrides?: ShareExternalsOptions;
   } = {},
   repo: PackageJsonRepository = sharedPackageJsonRepository
-): ResolvedSharedExternalsConfig | null {
+): ResolvedSharedExternalsConfig {
   // let workspacePath: string | undefined = undefined;
   const projectPath = inferProjectPath(opts.projectPath);
 


### PR DESCRIPTION
Closes #74 

This pull request makes a minor update to the `share-utils.ts` utility by changing the return type of the `shareAll` and `shareAllCore` functions from possibly returning `null` to always returning a `ResolvedSharedExternalsConfig` object. This simplifies the function signatures and clarifies that these functions will always return a valid configuration.

- Type signature changes:
  * `shareAll` and `shareAllCore` now always return a `ResolvedSharedExternalsConfig` instead of possibly returning `null`. [[1]](diffhunk://#diff-3083afbbcd6e216158616cad616a57464ddd31f539ec4ca68663b68571136256L363-R363) [[2]](diffhunk://#diff-3083afbbcd6e216158616cad616a57464ddd31f539ec4ca68663b68571136256L376-R376)