### PR TITLE
feat: New fromPackageJson builder

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,7 @@
 export * from './lib/domain/config/index.js';
 
 export { withNativeFederation } from './lib/config/with-native-federation.js';
-export {
-  findRootTsConfigJson,
-  share,
-  shareAll,
-  setInferVersion,
-} from './lib/config/share-utils.js';
+export { findRootTsConfigJson } from './lib/config/project-paths.js';
+export { setInferVersion } from './lib/config/version-lookup.js';
+export { share, shareAll, fromPackageJson } from './lib/config/share-utils.js';
 export { DEFAULT_SKIP_LIST } from './lib/config/default-skip-list.js';

--- a/src/lib/config/project-paths.spec.ts
+++ b/src/lib/config/project-paths.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import * as path from 'path';
+import { cwd } from 'process';
+import { findRootTsConfigJsonCore } from './project-paths.js';
+import { createMemoryIo } from '../utils/io/__test-helpers__/memory-io.js';
+
+const ROOT = cwd();
+
+describe('findRootTsConfigJsonCore', () => {
+  const withPackageJson = () => createMemoryIo().setFile(path.join(ROOT, 'package.json'), '{}');
+
+  it('prefers tsconfig.base.json when both exist', () => {
+    const io = withPackageJson()
+      .setFile(path.join(ROOT, 'tsconfig.base.json'), '{}')
+      .setFile(path.join(ROOT, 'tsconfig.json'), '{}');
+    expect(findRootTsConfigJsonCore(io)).toBe(path.join(ROOT, 'tsconfig.base.json'));
+  });
+
+  it('falls back to tsconfig.json when no base config exists', () => {
+    const io = withPackageJson().setFile(path.join(ROOT, 'tsconfig.json'), '{}');
+    expect(findRootTsConfigJsonCore(io)).toBe(path.join(ROOT, 'tsconfig.json'));
+  });
+
+  it('throws when neither config is present', () => {
+    expect(() => findRootTsConfigJsonCore(withPackageJson())).toThrow(/Neither a tsconfig/);
+  });
+});

--- a/src/lib/config/project-paths.ts
+++ b/src/lib/config/project-paths.ts
@@ -1,0 +1,54 @@
+import * as path from 'path';
+import { cwd } from 'process';
+import { getConfigContext } from './configuration-context.js';
+import { nodeIo } from '../utils/io/node-io-adapter.js';
+import type { FileReaderPort } from '../domain/utils/io-port.contract.js';
+
+export function findRootTsConfigJson(): string {
+  return findRootTsConfigJsonCore(nodeIo);
+}
+
+export function findRootTsConfigJsonCore(io: FileReaderPort): string {
+  const packageJson = findPackageJson(io, cwd());
+  const projectRoot = path.dirname(packageJson);
+  const tsConfigBaseJson = path.join(projectRoot, 'tsconfig.base.json');
+  const tsConfigJson = path.join(projectRoot, 'tsconfig.json');
+
+  if (io.exists(tsConfigBaseJson)) {
+    return tsConfigBaseJson;
+  } else if (io.exists(tsConfigJson)) {
+    return tsConfigJson;
+  }
+
+  throw new Error('Neither a tsconfig.json nor a tsconfig.base.json was found');
+}
+
+export function findPackageJson(io: FileReaderPort, folder: string): string {
+  while (!io.exists(path.join(folder, 'package.json')) && path.dirname(folder) !== folder) {
+    folder = path.dirname(folder);
+  }
+
+  const filePath = path.join(folder, 'package.json');
+  if (io.exists(filePath)) {
+    return filePath;
+  }
+
+  throw new Error(
+    'no package.json found. Searched the following folder and all parents: ' + folder
+  );
+}
+
+export function inferProjectPath(projectPath: string | undefined): string {
+  if (!projectPath && getConfigContext().packageJson) {
+    projectPath = path.dirname(getConfigContext().packageJson || '');
+  }
+
+  if (!projectPath && getConfigContext().workspaceRoot) {
+    projectPath = getConfigContext().workspaceRoot || '';
+  }
+
+  if (!projectPath) {
+    projectPath = cwd();
+  }
+  return projectPath;
+}

--- a/src/lib/config/secondaries.spec.ts
+++ b/src/lib/config/secondaries.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import * as path from 'path';
+import { getSecondaries } from './secondaries.js';
+import { prepareSkipList } from './default-skip-list.js';
+import { createMemoryIo } from '../utils/io/__test-helpers__/memory-io.js';
+import type { ExternalConfig } from '../domain/config/external-config.contract.js';
+
+const EMPTY_SKIP = prepareSkipList([]);
+const shareObject: ExternalConfig = { singleton: true, requiredVersion: '^1.0.0' };
+
+describe('getSecondaries', () => {
+  const LIB = path.resolve('/root/node_modules/mylib');
+
+  it('returns an empty map when the lib path does not exist', () => {
+    expect(getSecondaries(createMemoryIo(), true, LIB, 'mylib', shareObject, EMPTY_SKIP)).toEqual(
+      {}
+    );
+  });
+
+  it('reads configured secondaries from the package.json exports map', () => {
+    const io = createMemoryIo().setFile(
+      path.join(LIB, 'package.json'),
+      JSON.stringify({
+        version: '1.2.3',
+        type: 'module',
+        exports: {
+          '.': './index.js',
+          './sub': { default: './sub/index.js' },
+        },
+      })
+    );
+
+    const result = getSecondaries(io, true, LIB, 'mylib', shareObject, EMPTY_SKIP);
+
+    expect(Object.keys(result!)).toEqual(['mylib/sub']);
+    expect(result!['mylib/sub']).toMatchObject({ singleton: true });
+  });
+
+  it('resolves a glob whose pattern has no JS extension and filters non-JS files', () => {
+    const io = createMemoryIo()
+      .setFile(
+        path.join(LIB, 'package.json'),
+        JSON.stringify({
+          version: '1.2.3',
+          type: 'module',
+          exports: {
+            '.': './index.js',
+            './components/*': './components/*',
+          },
+        })
+      )
+      .setFile(path.join(LIB, 'components', 'button.js'), '')
+      .setFile(path.join(LIB, 'components', 'icon.mjs'), '')
+      .setFile(path.join(LIB, 'components', 'styles.css'), '')
+      .setFile(path.join(LIB, 'components', 'logo.svg'), '');
+
+    const result = getSecondaries(
+      io,
+      { skip: [], resolveGlob: true },
+      LIB,
+      'mylib',
+      shareObject,
+      EMPTY_SKIP
+    );
+
+    expect(Object.keys(result!).sort()).toEqual([
+      'mylib/components/button.js',
+      'mylib/components/icon.mjs',
+    ]);
+  });
+
+  it('falls back to walking subfolders (readDir) when there is no exports map', () => {
+    const io = createMemoryIo()
+      .setFile(path.join(LIB, 'sub', 'package.json'), '{}')
+      .setFile(path.join(LIB, 'node_modules', 'dep', 'package.json'), '{}');
+
+    const result = getSecondaries(io, true, LIB, 'mylib', shareObject, EMPTY_SKIP);
+
+    expect(Object.keys(result!)).toEqual(['mylib/sub']);
+  });
+
+  it('honours a custom skip list during the folder walk', () => {
+    const io = createMemoryIo().setFile(path.join(LIB, 'sub', 'package.json'), '{}');
+
+    const result = getSecondaries(
+      io,
+      { skip: ['mylib/sub'] },
+      LIB,
+      'mylib',
+      shareObject,
+      EMPTY_SKIP
+    );
+
+    expect(result).toEqual({});
+  });
+});

--- a/src/lib/config/secondaries.ts
+++ b/src/lib/config/secondaries.ts
@@ -1,0 +1,281 @@
+import * as path from 'path';
+import { isInSkipList } from './default-skip-list.js';
+import { type PreparedSkipList } from '../domain/config/skip-list.contract.js';
+import type { FileReaderPort, GlobPort } from '../domain/utils/io-port.contract.js';
+import { resolvePackageJsonExportsWildcardCore } from '../utils/package/resolve-wildcard-keys.js';
+import { logger } from '../utils/logger.js';
+import type {
+  ExternalConfig,
+  IncludeSecondariesOptions,
+  SharedExternalsConfig,
+} from '../domain/config/external-config.contract.js';
+import type { KeyValuePair } from '../domain/utils/keyvaluepair.contract.js';
+
+function _findSecondaries(
+  io: FileReaderPort,
+  libPath: string,
+  excludes: string[],
+  shareObject: ExternalConfig,
+  acc: SharedExternalsConfig,
+  preparedSkipList: PreparedSkipList
+): void {
+  const files = io.readDir(libPath);
+
+  const secondaries = files
+    .map(f => path.join(libPath, f))
+    .filter(f => io.isDirectory(f) && !f.endsWith('node_modules'));
+
+  for (const s of secondaries) {
+    if (io.exists(path.join(s, 'package.json'))) {
+      const secondaryLibName = s.replace(/\\/g, '/').replace(/^.*node_modules[/]/, '');
+
+      const inCustomSkipList = excludes.some(
+        e =>
+          e === secondaryLibName || (e.endsWith('*') && secondaryLibName.startsWith(e.slice(0, -1)))
+      );
+      if (inCustomSkipList) continue;
+
+      if (isInSkipList(secondaryLibName, preparedSkipList)) {
+        continue;
+      }
+
+      acc[secondaryLibName] = { ...shareObject };
+    }
+
+    _findSecondaries(io, s, excludes, shareObject, acc, preparedSkipList);
+  }
+}
+
+function findSecondaries(
+  io: FileReaderPort,
+  libPath: string,
+  excludes: string[],
+  shareObject: ExternalConfig,
+  preparedSkipList: PreparedSkipList
+): SharedExternalsConfig {
+  const acc = {} as SharedExternalsConfig;
+  _findSecondaries(io, libPath, excludes, shareObject, acc, preparedSkipList);
+  return acc;
+}
+
+export function getSecondaries(
+  io: FileReaderPort & GlobPort,
+  includeSecondaries: IncludeSecondariesOptions,
+  libPath: string,
+  key: string,
+  shareObject: ExternalConfig,
+  preparedSkipList: PreparedSkipList
+): SharedExternalsConfig | null {
+  let exclude: string[] = [];
+
+  let resolveGlob = false;
+  if (typeof includeSecondaries === 'object') {
+    if (includeSecondaries.skip) {
+      if (Array.isArray(includeSecondaries.skip)) {
+        exclude = includeSecondaries.skip;
+      } else if (typeof includeSecondaries.skip === 'string') {
+        exclude = [includeSecondaries.skip];
+      }
+    }
+
+    resolveGlob = !!includeSecondaries.resolveGlob;
+  }
+
+  if (!io.exists(libPath)) {
+    return {};
+  }
+
+  const configured = readConfiguredSecondaries(
+    io,
+    key,
+    libPath,
+    exclude,
+    shareObject,
+    preparedSkipList,
+    resolveGlob
+  );
+  if (configured) {
+    return configured;
+  }
+
+  // Fallback: Search folders
+  const secondaries = findSecondaries(io, libPath, exclude, shareObject, preparedSkipList);
+  return secondaries;
+}
+
+function readConfiguredSecondaries(
+  io: FileReaderPort & GlobPort,
+  parent: string,
+  libPath: string,
+  exclude: string[],
+  shareObject: ExternalConfig,
+  preparedSkipList: PreparedSkipList,
+  resolveGlob: boolean
+): SharedExternalsConfig | null {
+  const libPackageJson = path.join(libPath, 'package.json');
+
+  if (!io.exists(libPackageJson)) {
+    return null;
+  }
+
+  const packageJson = JSON.parse(io.readText(libPackageJson));
+
+  const version = packageJson['version'] as string;
+  const esm = packageJson['type'] === 'module';
+
+  const exports = packageJson['exports'] as Record<string, Record<string, string>>;
+
+  if (!exports) {
+    return null;
+  }
+
+  const keys = Object.keys(exports).filter(
+    key =>
+      key !== '.' &&
+      key !== './package.json' &&
+      key.startsWith('./') &&
+      (exports[key]?.['default'] || exports[key]?.['import'] || typeof exports[key] === 'string')
+  );
+
+  const result = {} as SharedExternalsConfig;
+  const discoveredFiles = new Set<string>();
+
+  for (const key of keys) {
+    const secondaryName = path.join(parent, key).replace(/\\/g, '/');
+
+    const inCustomSkipList = exclude.some(
+      e => e === secondaryName || (e.endsWith('*') && secondaryName.startsWith(e.slice(0, -1)))
+    );
+    if (inCustomSkipList) continue;
+
+    if (isInSkipList(secondaryName, preparedSkipList)) {
+      continue;
+    }
+
+    const entry = getDefaultEntry(exports, key);
+
+    if (typeof entry !== 'string') {
+      logger.warn('No entry point found for ' + secondaryName);
+      continue;
+    }
+
+    if (!key.includes('*') && !isJsFile(entry)) {
+      continue;
+    }
+
+    const items = resolveGlobSecondaries(
+      io,
+      key,
+      libPath,
+      parent,
+      secondaryName,
+      entry,
+      { discovered: discoveredFiles, skip: exclude },
+      resolveGlob
+    );
+    items.forEach(e => discoveredFiles.add(typeof e === 'string' ? e : e.value));
+
+    for (const item of items) {
+      if (typeof item === 'object') {
+        result[item.key] = {
+          ...shareObject,
+          packageInfo: {
+            entryPoint: item.value,
+            version: shareObject.version ?? version,
+            esm,
+          },
+        };
+      } else {
+        result[item] = {
+          ...shareObject,
+        };
+      }
+    }
+  }
+
+  return result;
+}
+
+function resolveGlobSecondaries(
+  io: GlobPort,
+  key: string,
+  libPath: string,
+  parent: string,
+  secondaryName: string,
+  entry: string,
+  excludes: { discovered: Set<string>; skip: string[] },
+  resolveGlob: boolean
+): Array<string | KeyValuePair> {
+  let items: Array<string | KeyValuePair> = [];
+  if (key.includes('*')) {
+    if (!resolveGlob) return items;
+    const expanded = resolvePackageJsonExportsWildcardCore(io, key, entry, libPath);
+    items = expanded
+      .map(e => ({
+        key: path.join(parent, e.key),
+        value: path.join(libPath, e.value),
+      }))
+      .filter(i => {
+        if (!isJsFile(i.value)) {
+          return false;
+        }
+        if (
+          excludes.skip.some(e =>
+            e.endsWith('*') ? i.key.startsWith(e.slice(0, -1)) : e === i.key
+          )
+        ) {
+          return false;
+        }
+        if (excludes.discovered.has(i.value)) {
+          return false;
+        }
+        return true;
+      });
+  } else {
+    items = [secondaryName];
+  }
+  return items;
+}
+
+function isJsFile(file: string): boolean {
+  return file.endsWith('.js') || file.endsWith('.mjs') || file.endsWith('.cjs');
+}
+
+function getDefaultEntry(exports: Record<string, Record<string, string>>, key: string) {
+  let entry: string | undefined = '';
+  if (typeof exports[key] === 'string') {
+    entry = exports[key] as unknown as string;
+  }
+
+  if (!entry) {
+    entry = exports[key]?.['default'];
+    if (typeof entry === 'object') {
+      entry = entry['default'];
+    }
+  }
+
+  if (!entry) {
+    entry = exports[key]?.['import'];
+    if (typeof entry === 'object') {
+      entry = entry['import'] ?? entry['default'];
+    }
+  }
+
+  if (!entry) {
+    entry = exports[key]?.['require'];
+    if (typeof entry === 'object') {
+      entry = entry['require'] ?? entry['default'];
+    }
+  }
+
+  return entry;
+}
+
+export function addSecondaries(
+  secondaries: Record<string, ExternalConfig>,
+  result: Record<string, ExternalConfig>
+) {
+  for (const key in secondaries) {
+    result[key] = secondaries[key]!;
+  }
+}

--- a/src/lib/config/share-utils.spec.ts
+++ b/src/lib/config/share-utils.spec.ts
@@ -1,122 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import * as path from 'path';
-import { cwd } from 'process';
-import { findRootTsConfigJsonCore, getSecondaries, shareAllCore, shareCore } from './share-utils.js';
-import { DEFAULT_SKIP_LIST, prepareSkipList } from './default-skip-list.js';
+import { shareAllCore, shareCore } from './share-utils.js';
+import { DEFAULT_SKIP_LIST } from './default-skip-list.js';
+import { logger } from '../utils/logger.js';
 import { createMemoryIo } from '../utils/io/__test-helpers__/memory-io.js';
 import { createPackageJsonRepository } from '../utils/io/package-json-repository.js';
-import type { ExternalConfig } from '../domain/config/external-config.contract.js';
-
-const ROOT = cwd();
-const EMPTY_SKIP = prepareSkipList([]);
-const shareObject: ExternalConfig = { singleton: true, requiredVersion: '^1.0.0' };
-
-describe('findRootTsConfigJsonCore', () => {
-  const withPackageJson = () => createMemoryIo().setFile(path.join(ROOT, 'package.json'), '{}');
-
-  it('prefers tsconfig.base.json when both exist', () => {
-    const io = withPackageJson()
-      .setFile(path.join(ROOT, 'tsconfig.base.json'), '{}')
-      .setFile(path.join(ROOT, 'tsconfig.json'), '{}');
-    expect(findRootTsConfigJsonCore(io)).toBe(path.join(ROOT, 'tsconfig.base.json'));
-  });
-
-  it('falls back to tsconfig.json when no base config exists', () => {
-    const io = withPackageJson().setFile(path.join(ROOT, 'tsconfig.json'), '{}');
-    expect(findRootTsConfigJsonCore(io)).toBe(path.join(ROOT, 'tsconfig.json'));
-  });
-
-  it('throws when neither config is present', () => {
-    expect(() => findRootTsConfigJsonCore(withPackageJson())).toThrow(/Neither a tsconfig/);
-  });
-});
-
-describe('getSecondaries', () => {
-  const LIB = path.resolve('/root/node_modules/mylib');
-
-  it('returns an empty map when the lib path does not exist', () => {
-    expect(getSecondaries(createMemoryIo(), true, LIB, 'mylib', shareObject, EMPTY_SKIP)).toEqual(
-      {}
-    );
-  });
-
-  it('reads configured secondaries from the package.json exports map', () => {
-    const io = createMemoryIo().setFile(
-      path.join(LIB, 'package.json'),
-      JSON.stringify({
-        version: '1.2.3',
-        type: 'module',
-        exports: {
-          '.': './index.js',
-          './sub': { default: './sub/index.js' },
-        },
-      })
-    );
-
-    const result = getSecondaries(io, true, LIB, 'mylib', shareObject, EMPTY_SKIP);
-
-    expect(Object.keys(result!)).toEqual(['mylib/sub']);
-    expect(result!['mylib/sub']).toMatchObject({ singleton: true });
-  });
-
-  it('resolves a glob whose pattern has no JS extension and filters non-JS files', () => {
-    const io = createMemoryIo()
-      .setFile(
-        path.join(LIB, 'package.json'),
-        JSON.stringify({
-          version: '1.2.3',
-          type: 'module',
-          exports: {
-            '.': './index.js',
-            './components/*': './components/*',
-          },
-        })
-      )
-      .setFile(path.join(LIB, 'components', 'button.js'), '')
-      .setFile(path.join(LIB, 'components', 'icon.mjs'), '')
-      .setFile(path.join(LIB, 'components', 'styles.css'), '')
-      .setFile(path.join(LIB, 'components', 'logo.svg'), '');
-
-    const result = getSecondaries(
-      io,
-      { skip: [], resolveGlob: true },
-      LIB,
-      'mylib',
-      shareObject,
-      EMPTY_SKIP
-    );
-
-    expect(Object.keys(result!).sort()).toEqual([
-      'mylib/components/button.js',
-      'mylib/components/icon.mjs',
-    ]);
-  });
-
-  it('falls back to walking subfolders (readDir) when there is no exports map', () => {
-    const io = createMemoryIo()
-      .setFile(path.join(LIB, 'sub', 'package.json'), '{}')
-      .setFile(path.join(LIB, 'node_modules', 'dep', 'package.json'), '{}');
-
-    const result = getSecondaries(io, true, LIB, 'mylib', shareObject, EMPTY_SKIP);
-
-    expect(Object.keys(result!)).toEqual(['mylib/sub']);
-  });
-
-  it('honours a custom skip list during the folder walk', () => {
-    const io = createMemoryIo().setFile(path.join(LIB, 'sub', 'package.json'), '{}');
-
-    const result = getSecondaries(
-      io,
-      { skip: ['mylib/sub'] },
-      LIB,
-      'mylib',
-      shareObject,
-      EMPTY_SKIP
-    );
-
-    expect(result).toEqual({});
-  });
-});
 
 describe('shareCore (end-to-end via injected repository)', () => {
   const PROJECT = path.resolve('/ws/app');
@@ -203,7 +91,9 @@ describe('shareAllCore (end-to-end via injected repository)', () => {
       {
         projectPath: PROJECT,
         skipList: ['skipme'],
-        overrides: { overridden: { singleton: false, requiredVersion: '~3.1.0', includeSecondaries: false } },
+        overrides: {
+          overridden: { singleton: false, requiredVersion: '~3.1.0', includeSecondaries: false },
+        },
       },
       repo
     );
@@ -211,5 +101,73 @@ describe('shareAllCore (end-to-end via injected repository)', () => {
     expect(Object.keys(result!).sort()).toEqual(['mylib', 'overridden']);
     expect(result!['mylib']).toMatchObject({ singleton: true, requiredVersion: '^1.2.3' });
     expect(result!['overridden']).toMatchObject({ singleton: false, requiredVersion: '~3.1.0' });
+  });
+
+  it('patches a shared external in place', () => {
+    const io = createMemoryIo().setFile(
+      path.join(PROJECT, 'package.json'),
+      JSON.stringify({ dependencies: { mylib: '^1.2.3' } })
+    );
+    const repo = createPackageJsonRepository(io);
+
+    const result = shareAllCore(
+      io,
+      { singleton: true, includeSecondaries: false },
+      { projectPath: PROJECT, patchList: { mylib: { singleton: false, strictVersion: true } } },
+      repo
+    );
+
+    expect(result!['mylib']).toMatchObject({
+      singleton: false,
+      strictVersion: true,
+      requiredVersion: '^1.2.3',
+    });
+  });
+
+  it('ignores a patch for an external that is not shared and warns', () => {
+    const io = createMemoryIo().setFile(
+      path.join(PROJECT, 'package.json'),
+      JSON.stringify({ dependencies: { mylib: '^1.2.3' } })
+    );
+    const repo = createPackageJsonRepository(io);
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const result = shareAllCore(
+      io,
+      { singleton: true, includeSecondaries: false },
+      { projectPath: PROJECT, patchList: { doesnotexist: { singleton: false } } },
+      repo
+    );
+
+    expect(Object.keys(result!)).toEqual(['mylib']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('not a shared external'));
+    warn.mockRestore();
+  });
+
+  it('ignores a patch for an external that is shadowed by overrides and warns', () => {
+    const io = createMemoryIo().setFile(
+      path.join(PROJECT, 'package.json'),
+      JSON.stringify({ dependencies: { overridden: '^3.0.0' } })
+    );
+    const repo = createPackageJsonRepository(io);
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const result = shareAllCore(
+      io,
+      { singleton: true, includeSecondaries: false },
+      {
+        projectPath: PROJECT,
+        overrides: {
+          overridden: { singleton: false, requiredVersion: '~3.1.0', includeSecondaries: false },
+        },
+        patchList: { overridden: { singleton: true } },
+      },
+      repo
+    );
+
+    // The override value wins; the patch is not applied.
+    expect(result!['overridden']).toMatchObject({ singleton: false, requiredVersion: '~3.1.0' });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('mutually exclusive'));
+    warn.mockRestore();
   });
 });

--- a/src/lib/config/share-utils.ts
+++ b/src/lib/config/share-utils.ts
@@ -1,20 +1,15 @@
 import * as path from 'path';
-import { cwd } from 'process';
 import { DEFAULT_SKIP_LIST, isInSkipList, prepareSkipList } from './default-skip-list.js';
-import { type SkipList, type PreparedSkipList } from '../domain/config/skip-list.contract.js';
+import { type SkipList } from '../domain/config/skip-list.contract.js';
 import {
   sharedPackageJsonRepository,
   findDepPackageJson,
   getVersionMaps,
-  type VersionMap,
 } from '../utils/package/package-info.js';
 import type { PackageJsonRepository } from '../domain/utils/package-json.contract.js';
-import { getConfigContext } from './configuration-context.js';
 import { logger } from '../utils/logger.js';
 import { nodeIo } from '../utils/io/node-io-adapter.js';
 import type { FileReaderPort, GlobPort } from '../domain/utils/io-port.contract.js';
-
-import { resolvePackageJsonExportsWildcardCore } from '../utils/package/resolve-wildcard-keys.js';
 import type {
   ExternalConfig,
   IncludeSecondariesOptions,
@@ -23,336 +18,60 @@ import type {
   SharedExternalsConfig,
   ShareExternalsOptions,
 } from '../domain/config/external-config.contract.js';
-import type { KeyValuePair } from '../domain/utils/keyvaluepair.contract.js';
+import { findPackageJson, inferProjectPath } from './project-paths.js';
+import { isInferVersion, lookupVersion } from './version-lookup.js';
+import { addSecondaries, getSecondaries } from './secondaries.js';
 
-let inferVersion = false;
+export const fromPackageJson = (baseCfg: ShareAllExternalsOptions, projectPath?: string) => {
+  const skipList: SkipList = [...DEFAULT_SKIP_LIST];
+  let overrides: ShareExternalsOptions = {};
+  const patchList: Record<string, Partial<ExternalConfig>> = {};
 
-export function findRootTsConfigJson(): string {
-  return findRootTsConfigJsonCore(nodeIo);
-}
-
-export function findRootTsConfigJsonCore(io: FileReaderPort): string {
-  const packageJson = findPackageJson(io, cwd());
-  const projectRoot = path.dirname(packageJson);
-  const tsConfigBaseJson = path.join(projectRoot, 'tsconfig.base.json');
-  const tsConfigJson = path.join(projectRoot, 'tsconfig.json');
-
-  if (io.exists(tsConfigBaseJson)) {
-    return tsConfigBaseJson;
-  } else if (io.exists(tsConfigJson)) {
-    return tsConfigJson;
-  }
-
-  throw new Error('Neither a tsconfig.json nor a tsconfig.base.json was found');
-}
-
-function findPackageJson(io: FileReaderPort, folder: string): string {
-  while (!io.exists(path.join(folder, 'package.json')) && path.dirname(folder) !== folder) {
-    folder = path.dirname(folder);
-  }
-
-  const filePath = path.join(folder, 'package.json');
-  if (io.exists(filePath)) {
-    return filePath;
-  }
-
-  throw new Error(
-    'no package.json found. Searched the following folder and all parents: ' + folder
-  );
-}
-
-function lookupVersion(key: string, workspaceRoot: string, repo: PackageJsonRepository): string {
-  const versionMaps = getVersionMaps(workspaceRoot, workspaceRoot, repo);
-
-  for (const versionMap of versionMaps) {
-    const version = lookupVersionInMap(key, versionMap);
-
-    if (version) {
-      return version;
-    }
-  }
-
-  throw new Error(
-    `Shared Dependency ${key} has requiredVersion:'auto'. However, this dependency is not found in your package.json`
-  );
-}
-
-function lookupVersionInMap(key: string, versions: VersionMap): string | null {
-  const parts = key.split('/');
-  if (parts.length >= 2 && parts[0]!.startsWith('@')) {
-    key = parts[0] + '/' + parts[1];
-  } else {
-    key = parts[0]!;
-  }
-
-  if (!versions[key]) {
-    return null;
-  }
-  return versions[key]!;
-}
-
-function _findSecondaries(
-  io: FileReaderPort,
-  libPath: string,
-  excludes: string[],
-  shareObject: ExternalConfig,
-  acc: SharedExternalsConfig,
-  preparedSkipList: PreparedSkipList
-): void {
-  const files = io.readDir(libPath);
-
-  const secondaries = files
-    .map(f => path.join(libPath, f))
-    .filter(f => io.isDirectory(f) && !f.endsWith('node_modules'));
-
-  for (const s of secondaries) {
-    if (io.exists(path.join(s, 'package.json'))) {
-      const secondaryLibName = s.replace(/\\/g, '/').replace(/^.*node_modules[/]/, '');
-
-      const inCustomSkipList = excludes.some(
-        e =>
-          e === secondaryLibName || (e.endsWith('*') && secondaryLibName.startsWith(e.slice(0, -1)))
-      );
-      if (inCustomSkipList) continue;
-
-      if (isInSkipList(secondaryLibName, preparedSkipList)) {
-        continue;
-      }
-
-      acc[secondaryLibName] = { ...shareObject };
-    }
-
-    _findSecondaries(io, s, excludes, shareObject, acc, preparedSkipList);
-  }
-}
-
-function findSecondaries(
-  io: FileReaderPort,
-  libPath: string,
-  excludes: string[],
-  shareObject: ExternalConfig,
-  preparedSkipList: PreparedSkipList
-): SharedExternalsConfig {
-  const acc = {} as SharedExternalsConfig;
-  _findSecondaries(io, libPath, excludes, shareObject, acc, preparedSkipList);
-  return acc;
-}
-
-export function getSecondaries(
-  io: FileReaderPort & GlobPort,
-  includeSecondaries: IncludeSecondariesOptions,
-  libPath: string,
-  key: string,
-  shareObject: ExternalConfig,
-  preparedSkipList: PreparedSkipList
-): SharedExternalsConfig | null {
-  let exclude: string[] = [];
-
-  let resolveGlob = false;
-  if (typeof includeSecondaries === 'object') {
-    if (includeSecondaries.skip) {
-      if (Array.isArray(includeSecondaries.skip)) {
-        exclude = includeSecondaries.skip;
-      } else if (typeof includeSecondaries.skip === 'string') {
-        exclude = [includeSecondaries.skip];
-      }
-    }
-
-    resolveGlob = !!includeSecondaries.resolveGlob;
-  }
-
-  // const libPath = path.join(path.dirname(packagePath), 'node_modules', key);
-
-  if (!io.exists(libPath)) {
-    return {};
-  }
-
-  const configured = readConfiguredSecondaries(
-    io,
-    key,
-    libPath,
-    exclude,
-    shareObject,
-    preparedSkipList,
-    resolveGlob
-  );
-  if (configured) {
-    return configured;
-  }
-
-  // Fallback: Search folders
-  const secondaries = findSecondaries(io, libPath, exclude, shareObject, preparedSkipList);
-  return secondaries;
-}
-
-function readConfiguredSecondaries(
-  io: FileReaderPort & GlobPort,
-  parent: string,
-  libPath: string,
-  exclude: string[],
-  shareObject: ExternalConfig,
-  preparedSkipList: PreparedSkipList,
-  resolveGlob: boolean
-): SharedExternalsConfig | null {
-  const libPackageJson = path.join(libPath, 'package.json');
-
-  if (!io.exists(libPackageJson)) {
-    return null;
-  }
-
-  const packageJson = JSON.parse(io.readText(libPackageJson));
-
-  const version = packageJson['version'] as string;
-  const esm = packageJson['type'] === 'module';
-
-  const exports = packageJson['exports'] as Record<string, Record<string, string>>;
-
-  if (!exports) {
-    return null;
-  }
-
-  const keys = Object.keys(exports).filter(
-    key =>
-      key !== '.' &&
-      key !== './package.json' &&
-      key.startsWith('./') &&
-      (exports[key]?.['default'] || exports[key]?.['import'] || typeof exports[key] === 'string')
-  );
-
-  const result = {} as SharedExternalsConfig;
-  const discoveredFiles = new Set<string>();
-
-  for (const key of keys) {
-    const secondaryName = path.join(parent, key).replace(/\\/g, '/');
-
-    const inCustomSkipList = exclude.some(
-      e => e === secondaryName || (e.endsWith('*') && secondaryName.startsWith(e.slice(0, -1)))
-    );
-    if (inCustomSkipList) continue;
-
-    if (isInSkipList(secondaryName, preparedSkipList)) {
-      continue;
-    }
-
-    const entry = getDefaultEntry(exports, key);
-
-    if (typeof entry !== 'string') {
-      console.log('No entry point found for ' + secondaryName);
-      continue;
-    }
-
-    if (!key.includes('*') && !isJsFile(entry)) {
-      continue;
-    }
-
-    const items = resolveGlobSecondaries(
-      io,
-      key,
-      libPath,
-      parent,
-      secondaryName,
-      entry,
-      { discovered: discoveredFiles, skip: exclude },
-      resolveGlob
-    );
-    items.forEach(e => discoveredFiles.add(typeof e === 'string' ? e : e.value));
-
-    for (const item of items) {
-      if (typeof item === 'object') {
-        result[item.key] = {
-          ...shareObject,
-          packageInfo: {
-            entryPoint: item.value,
-            version: shareObject.version ?? version,
-            esm,
-          },
+  const builder = {
+    skip(externals: SkipList) {
+      skipList.push(...externals);
+      return builder;
+    },
+    override(externals: ShareExternalsOptions) {
+      overrides = { ...overrides, ...externals };
+      return builder;
+    },
+    patch(externals: string[], cfg: Partial<ExternalConfig>) {
+      externals.forEach(external => {
+        patchList[external] = {
+          ...(patchList[external] ?? {}),
+          ...cfg,
         };
-      } else {
-        result[item] = {
-          ...shareObject,
-        };
-      }
-    }
-  }
-
-  return result;
-}
-
-function resolveGlobSecondaries(
-  io: GlobPort,
-  key: string,
-  libPath: string,
-  parent: string,
-  secondaryName: string,
-  entry: string,
-  excludes: { discovered: Set<string>; skip: string[] },
-  resolveGlob: boolean
-): Array<string | KeyValuePair> {
-  let items: Array<string | KeyValuePair> = [];
-  if (key.includes('*')) {
-    if (!resolveGlob) return items;
-    const expanded = resolvePackageJsonExportsWildcardCore(io, key, entry, libPath);
-    items = expanded
-      .map(e => ({
-        key: path.join(parent, e.key),
-        value: path.join(libPath, e.value),
-      }))
-      .filter(i => {
-        if (!isJsFile(i.value)) {
-          return false;
-        }
-        if (
-          excludes.skip.some(e =>
-            e.endsWith('*') ? i.key.startsWith(e.slice(0, -1)) : e === i.key
-          )
-        ) {
-          return false;
-        }
-        if (excludes.discovered.has(i.value)) {
-          return false;
-        }
-        return true;
       });
-  } else {
-    items = [secondaryName];
-  }
-  return items;
-}
+      return builder;
+    },
+    get() {
+      return shareAllCore(nodeIo, baseCfg, {
+        skipList,
+        projectPath,
+        overrides,
+        patchList,
+      });
+    },
+  };
 
-function isJsFile(file: string): boolean {
-  return file.endsWith('.js') || file.endsWith('.mjs') || file.endsWith('.cjs');
-}
+  return builder;
+};
 
-function getDefaultEntry(exports: Record<string, Record<string, string>>, key: string) {
-  let entry: string | undefined = '';
-  if (typeof exports[key] === 'string') {
-    entry = exports[key] as unknown as string;
-  }
-
-  if (!entry) {
-    entry = exports[key]?.['default'];
-    if (typeof entry === 'object') {
-      entry = entry['default'];
-    }
-  }
-
-  if (!entry) {
-    entry = exports[key]?.['import'];
-    if (typeof entry === 'object') {
-      entry = entry['import'] ?? entry['default'];
-    }
-  }
-
-  if (!entry) {
-    entry = exports[key]?.['require'];
-    if (typeof entry === 'object') {
-      entry = entry['require'] ?? entry['default'];
-    }
-  }
-
-  return entry;
-}
-
+/**
+ * @deprecated Use {@link fromPackageJson} instead, which offers a fluent,
+ * composable API for skipping, overriding and patching shared externals:
+ *
+ * ```ts
+ * // before
+ * shareAll(config, { skipList, overrides });
+ * // after
+ * fromPackageJson(config).skip(skipList).override(overrides).get();
+ * ```
+ *
+ * Note: `fromPackageJson().skip()` *extends* the default skip list, whereas
+ * `shareAll`'s `skipList` option *replaces* it.
+ */
 export function shareAll(
   config: ShareAllExternalsOptions,
   opts: {
@@ -371,17 +90,11 @@ export function shareAllCore(
     skipList?: SkipList;
     projectPath?: string;
     overrides?: ShareExternalsOptions;
+    patchList?: Record<string, Partial<ExternalConfig>>;
   } = {},
   repo: PackageJsonRepository = sharedPackageJsonRepository
 ): ResolvedSharedExternalsConfig {
-  // let workspacePath: string | undefined = undefined;
   const projectPath = inferProjectPath(opts.projectPath);
-
-  // workspacePath = getConfigContext().workspaceRoot ?? '';
-
-  // if (!workspacePath) {
-  //   workspacePath = projectPath;
-  // }
 
   const versionMaps = getVersionMaps(projectPath, projectPath, repo);
   const sharedExternals: ShareExternalsOptions = {};
@@ -405,29 +118,47 @@ export function shareAllCore(
     }
   }
 
+  const finalExternalList = applyPatchList(sharedExternals, opts.patchList, opts.overrides);
+
   return {
-    ...shareCore(io, sharedExternals, opts.projectPath, skipList, repo),
+    ...shareCore(io, finalExternalList, opts.projectPath, skipList, repo),
     ...(!opts.overrides ? {} : shareCore(io, opts.overrides, opts.projectPath, skipList, repo)),
   };
 }
 
-function inferProjectPath(projectPath: string | undefined) {
-  if (!projectPath && getConfigContext().packageJson) {
-    projectPath = path.dirname(getConfigContext().packageJson || '');
+/**
+ * Merges `patchList` overrides onto the shared externals. Patches only affect
+ * externals that are actually being shared: a patch for an external that isn't
+ * in the list (unknown dependency, skipped, or shadowed by `overrides`) is
+ * ignored with a warning.
+ */
+function applyPatchList(
+  sharedExternals: ShareExternalsOptions,
+  patchList: Record<string, Partial<ExternalConfig>> | undefined,
+  overrides: ShareExternalsOptions | undefined
+): ShareExternalsOptions {
+  if (!patchList) {
+    return sharedExternals;
   }
 
-  if (!projectPath && getConfigContext().workspaceRoot) {
-    projectPath = getConfigContext().workspaceRoot || '';
+  const result = { ...sharedExternals };
+
+  for (const [external, cfg] of Object.entries(patchList)) {
+    if (!result[external]) {
+      const shadowedByOverride =
+        !!overrides && Object.keys(overrides).some(o => external.startsWith(o));
+      logger.warn(
+        shadowedByOverride
+          ? `Ignoring patch for '${external}': it is already configured via 'overrides' ('patch' and 'overrides' are mutually exclusive per external).`
+          : `Ignoring patch for '${external}': it is not a shared external (unknown dependency or skipped).`
+      );
+      continue;
+    }
+
+    result[external] = { ...result[external], ...cfg };
   }
 
-  if (!projectPath) {
-    projectPath = cwd();
-  }
-  return projectPath;
-}
-
-export function setInferVersion(infer: boolean): void {
-  inferVersion = infer;
+  return result;
 }
 
 export function share(
@@ -452,17 +183,16 @@ export function shareCore(
 
   const shareObjects = { ...configuredShareObjects };
 
-  const result: any = {};
-  let includeSecondaries;
+  const result: SharedExternalsConfig = {};
 
   for (const key in shareObjects) {
-    includeSecondaries = false;
-    const shareObject = (shareObjects as any)[key];
+    let includeSecondaries: IncludeSecondariesOptions = false;
+    const shareObject = shareObjects[key]!;
 
     if (
       shareObject.requiredVersion === 'auto' ||
-      (inferVersion && typeof shareObject.requiredVersion === 'undefined') ||
-      shareObject.requiredVersion?.length < 1
+      (isInferVersion() && typeof shareObject.requiredVersion === 'undefined') ||
+      (shareObject.requiredVersion?.length ?? 1) < 1
     ) {
       const version = lookupVersion(key, projectPath, repo);
 
@@ -477,7 +207,9 @@ export function shareCore(
     if (shareObject.includeSecondaries) {
       includeSecondaries = shareObject.includeSecondaries;
       delete shareObject.includeSecondaries;
-      if (includeSecondaries?.keepAll) shareObject.includeSecondaries = true;
+      if (typeof includeSecondaries === 'object' && includeSecondaries.keepAll) {
+        shareObject.includeSecondaries = true;
+      }
     }
 
     result[key] = shareObject;
@@ -506,14 +238,5 @@ export function shareCore(
     }
   }
 
-  return result;
-}
-
-function addSecondaries(
-  secondaries: Record<string, ExternalConfig>,
-  result: Record<string, ExternalConfig>
-) {
-  for (const key in secondaries) {
-    result[key] = secondaries[key]!;
-  }
+  return result as ResolvedSharedExternalsConfig;
 }

--- a/src/lib/config/version-lookup.ts
+++ b/src/lib/config/version-lookup.ts
@@ -1,0 +1,46 @@
+import { getVersionMaps, type VersionMap } from '../utils/package/package-info.js';
+import type { PackageJsonRepository } from '../domain/utils/package-json.contract.js';
+
+let inferVersion = false;
+
+export function setInferVersion(infer: boolean): void {
+  inferVersion = infer;
+}
+
+export function isInferVersion(): boolean {
+  return inferVersion;
+}
+
+export function lookupVersion(
+  key: string,
+  workspaceRoot: string,
+  repo: PackageJsonRepository
+): string {
+  const versionMaps = getVersionMaps(workspaceRoot, workspaceRoot, repo);
+
+  for (const versionMap of versionMaps) {
+    const version = lookupVersionInMap(key, versionMap);
+
+    if (version) {
+      return version;
+    }
+  }
+
+  throw new Error(
+    `Shared Dependency ${key} has requiredVersion:'auto'. However, this dependency is not found in your package.json`
+  );
+}
+
+function lookupVersionInMap(key: string, versions: VersionMap): string | null {
+  const parts = key.split('/');
+  if (parts.length >= 2 && parts[0]!.startsWith('@')) {
+    key = parts[0] + '/' + parts[1];
+  } else {
+    key = parts[0]!;
+  }
+
+  if (!versions[key]) {
+    return null;
+  }
+  return versions[key]!;
+}

--- a/src/lib/config/with-native-federation.spec.ts
+++ b/src/lib/config/with-native-federation.spec.ts
@@ -1,13 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// with-native-federation reaches the filesystem through share-utils and
+// with-native-federation reaches the filesystem through share/project-paths and
 // mapped-paths; stub those so the normalization logic can be tested in isolation.
 const shareAll = vi.fn();
 const findRootTsConfigJson = vi.fn();
 const getRawMappedPaths = vi.fn();
 
 vi.mock('./share-utils.js', () => ({
-  shareAll: (...args: unknown[]) => shareAll(...args),
+  fromPackageJson: (...args: unknown[]) => ({ get: () => shareAll(...args) }),
+}));
+
+vi.mock('./project-paths.js', () => ({
   findRootTsConfigJson: (...args: unknown[]) => findRootTsConfigJson(...args),
 }));
 

--- a/src/lib/config/with-native-federation.ts
+++ b/src/lib/config/with-native-federation.ts
@@ -1,5 +1,6 @@
 import { getRawMappedPaths } from './mapped-paths.js';
-import { shareAll, findRootTsConfigJson } from './share-utils.js';
+import { fromPackageJson } from './share-utils.js';
+import { findRootTsConfigJson } from './project-paths.js';
 import type {
   ExposeEntry,
   FederationConfig,
@@ -40,9 +41,7 @@ export function withNativeFederation(config: FederationConfig): NormalizedFedera
   return normalized;
 }
 
-function normalizeExposes(
-  exposes: FederationConfig['exposes']
-): Record<string, ExposeEntry> {
+function normalizeExposes(exposes: FederationConfig['exposes']): Record<string, ExposeEntry> {
   if (!exposes) return {};
   return Object.fromEntries(
     Object.entries(exposes).map(([key, value]) => [
@@ -61,12 +60,12 @@ function normalizeShared(
 
   const shared =
     config.shared ??
-    (shareAll({
+    (fromPackageJson({
       singleton: true,
       strictVersion: true,
       requiredVersion: 'auto',
       platform: 'browser',
-    }) as NormalizedSharedExternalsConfig);
+    }).get() as NormalizedSharedExternalsConfig);
 
   result = Object.keys(shared).reduce<NormalizedSharedExternalsConfig>((acc, cur) => {
     const key = cur.replace(/\\/g, '/');


### PR DESCRIPTION
Closes #82 

This pull request refactors and reorganizes the configuration utilities, improves test coverage, and introduces new functionality for handling secondary entry points and version lookup in a modular way. The changes separate concerns into more focused modules, enhance testability, and add new features for patching shared externals.

**Key changes include:**

### Refactoring and Modularization

* Split utility functions from `share-utils.js` into dedicated modules: `project-paths.js` (for project/tsconfig discovery), `version-lookup.js` (for version inference and lookup), and kept only sharing-related logic in `share-utils.js`. The exports in `src/config.ts` are updated accordingly. [[1]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L4-R6) [[2]](diffhunk://#diff-6f8c162a1ce1efdfb8427b80b1d853d00f6cd5b6229a64e6ef510f43e4a87181R1-R54) [[3]](diffhunk://#diff-33c98036d8fa62cb83df8f01e64b5f0ff28c77925f3cf93a49cbdb2f2b3b4fc2R1-R46)

### Secondary Entry Points Handling

* Introduced a new `getSecondaries` function in `secondaries.ts` to robustly discover secondary entry points of shared libraries, supporting both `exports` maps and directory traversal, with support for custom skip lists and glob patterns. Comprehensive tests for this logic were added in `secondaries.spec.ts`. [[1]](diffhunk://#diff-3cb42abbd66915239ca2d95449c6c67b0c98c79adfa8bab5b5254e163e01a8d1R1-R281) [[2]](diffhunk://#diff-c0b98089d4d8ea9e0aac4590d22b13d6c989769ce8f13d9b40d9521a6e868942R1-R96)

### Version Lookup Improvements

* Added `setInferVersion`, `isInferVersion`, and `lookupVersion` functions in `version-lookup.ts` to manage and resolve package versions for shared dependencies, supporting "auto" version inference.

### Enhancements to Sharing Logic

* Updated `shareAllCore` to support patching shared externals in place and to warn when patches are ignored due to missing or overridden externals. New tests cover these scenarios. [[1]](diffhunk://#diff-022e3b2435f50f7cf7dce33ffd35c4532bb0611b7ff1b9f754eadafe65f5be97L206-R96) [[2]](diffhunk://#diff-022e3b2435f50f7cf7dce33ffd35c4532bb0611b7ff1b9f754eadafe65f5be97R105-R172)

### Test Suite Improvements

* Moved and expanded tests for project path and secondary entry point discovery into their respective new spec files, streamlining `share-utils.spec.ts` to focus on sharing logic. Updated mocks in `with-native-federation.spec.ts` to reflect the new modular structure. [[1]](diffhunk://#diff-022e3b2435f50f7cf7dce33ffd35c4532bb0611b7ff1b9f754eadafe65f5be97L1-L119) [[2]](diffhunk://#diff-de6da7bb65257e9e683e26f8c7f9881f5961903111f7c2e8b89fc10e6a025d61L3-R13) [[3]](diffhunk://#diff-9c8270d956b53a2715589ecb7c37881e1847641bb883b3f8772ffd001fd4167fR1-R27) [[4]](diffhunk://#diff-c0b98089d4d8ea9e0aac4590d22b13d6c989769ce8f13d9b40d9521a6e868942R1-R96)

These changes improve code maintainability, separation of concerns, and test coverage across the configuration utilities.