### PR TITLE
chore: Added 'pool' property

### DIFF
--- a/src/lib/config/with-native-federation.spec.ts
+++ b/src/lib/config/with-native-federation.spec.ts
@@ -160,6 +160,23 @@ describe('withNativeFederation', () => {
     expect(result.shared['react'].shareScope).toBe('isolated');
   });
 
+  it('passes a per-external pool through normalization', () => {
+    const result = withNativeFederation({
+      shared: { react: { pool: 'critical' } },
+    });
+
+    expect(result.shared['react'].pool).toBe('critical');
+  });
+
+  it('omits pool when it is not configured', () => {
+    const result = withNativeFederation({
+      shared: { react: {} },
+    });
+
+    expect(result.shared['react'].pool).toBeUndefined();
+    expect(result.shared['react']).not.toHaveProperty('pool');
+  });
+
   it('builds shared mappings from the resolved tsconfig, filtering the skip list', () => {
     getRawMappedPaths.mockReturnValue({
       '/ws/libs/ui/index.ts': '@org/ui',

--- a/src/lib/config/with-native-federation.ts
+++ b/src/lib/config/with-native-federation.ts
@@ -92,6 +92,7 @@ function normalizeShared(
       platform: sharedConfig.platform ?? config.platform ?? 'browser',
       build: sharedConfig.build ?? 'default',
       ...(sharedConfig.shareScope && { shareScope: sharedConfig.shareScope }),
+      ...(sharedConfig.pool && { pool: sharedConfig.pool }),
     };
     return {
       ...acc,

--- a/src/lib/core/build/bundle-shared.spec.ts
+++ b/src/lib/core/build/bundle-shared.spec.ts
@@ -196,6 +196,66 @@ describe('bundleSharedCore (via injected io, repo and build adapter)', () => {
     expect(mem.exists(path.join('/cache', 'shared.meta.json'))).toBe(true);
   });
 
+  it('carries a configured pool through to the shared external', async () => {
+    const mem = createMemoryIo().setFile(ROOT_PKG, '{}');
+    const adapter = createFakeBuildAdapter({ io: mem });
+    const sharedBundles: Record<string, NormalizedExternalConfig> = {
+      foo: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+        version: '1.0.0',
+        chunks: false,
+        platform: 'browser',
+        build: 'default',
+        pool: 'critical',
+        packageInfo: { entryPoint: 'foo/index.js', version: '1.0.0', esm: true },
+      },
+    };
+
+    const result = await bundleSharedCore(
+      { io: mem, repo: emptyRepo, adapter },
+      sharedBundles,
+      makeConfig(),
+      makeFedOptions(),
+      [],
+      BUILD_OPTIONS
+    );
+
+    expect(result.externals[0]).toMatchObject({
+      packageName: 'foo',
+      pool: 'critical',
+    });
+  });
+
+  it('omits pool from the shared external when it is not configured', async () => {
+    const mem = createMemoryIo().setFile(ROOT_PKG, '{}');
+    const adapter = createFakeBuildAdapter({ io: mem });
+    const sharedBundles: Record<string, NormalizedExternalConfig> = {
+      foo: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+        version: '1.0.0',
+        chunks: false,
+        platform: 'browser',
+        build: 'default',
+        packageInfo: { entryPoint: 'foo/index.js', version: '1.0.0', esm: true },
+      },
+    };
+
+    const result = await bundleSharedCore(
+      { io: mem, repo: emptyRepo, adapter },
+      sharedBundles,
+      makeConfig(),
+      makeFedOptions(),
+      [],
+      BUILD_OPTIONS
+    );
+
+    expect(result.externals[0]).not.toHaveProperty('pool');
+  });
+
   it('resolves an inferred package through the injected repository', async () => {
     const mem = createMemoryIo().setFile(ROOT_PKG, '{}');
     const adapter = createFakeBuildAdapter({ io: mem });

--- a/src/lib/core/build/bundle-shared.ts
+++ b/src/lib/core/build/bundle-shared.ts
@@ -324,12 +324,7 @@ function buildResult(
       strictVersion: shared?.strictVersion,
       version: pi.version,
       ...(shared?.shareScope && { shareScope: shared.shareScope }),
-      // TODO: Decide whether/when we need debug infos
-      // dev: !fedOptions.dev
-      //   ? undefined
-      //   : {
-      //       entryPoint: normalize(pi.entryPoint),
-      //     },
+      ...(shared?.pool && { pool: shared.pool }),
     } as SharedInfo;
   });
 }

--- a/src/lib/domain/config/external-config.contract.ts
+++ b/src/lib/domain/config/external-config.contract.ts
@@ -1,6 +1,5 @@
 export type IncludeSecondariesOptions =
-  | { skip?: string | string[]; resolveGlob?: boolean; keepAll?: boolean }
-  | boolean;
+  { skip?: string | string[]; resolveGlob?: boolean; keepAll?: boolean } | boolean;
 
 export interface ExternalConfig {
   singleton?: boolean;
@@ -10,6 +9,7 @@ export interface ExternalConfig {
   includeSecondaries?: IncludeSecondariesOptions;
   platform?: 'browser' | 'node';
   build?: 'separate' | 'package';
+  pool?: string;
   chunks?: boolean;
   shareScope?: string;
   packageInfo?: {
@@ -26,6 +26,7 @@ export interface NormalizedExternalConfig {
   version?: string;
   includeSecondaries?: boolean;
   shareScope?: string;
+  pool?: string;
   chunks: boolean;
   platform: 'browser' | 'node';
   build: 'default' | 'separate' | 'package';

--- a/src/lib/domain/core/federation-info.contract.ts
+++ b/src/lib/domain/core/federation-info.contract.ts
@@ -14,6 +14,7 @@ export type SharedInfo = {
   version?: string;
   packageName: string;
   shareScope?: string;
+  pool?: string;
   bundle?: string;
   outFileName: string;
   dev?: {


### PR DESCRIPTION
Linked to https://github.com/native-federation/orchestrator/issues/49

This pull request introduces support for a new optional pool property in the shared external configuration for module federation. The pool property allows specifying a resource pool for shared dependencies, and the changes ensure that this property is correctly handled throughout configuration normalization, build processing, and type definitions. The update also includes comprehensive tests to verify correct handling of the pool property when present and its omission when not configured.

**Type and Interface Updates:**

* Added an optional `pool` property to the `ExternalConfig`, `NormalizedExternalConfig`, and `SharedInfo` interfaces to allow specifying a resource pool for shared dependencies. [[1]](diffhunk://#diff-8e4e70a21fd9d75320c52c81c4d2eb933c660c8c1636c51f5d950a5f1071a1deR12) [[2]](diffhunk://#diff-8e4e70a21fd9d75320c52c81c4d2eb933c660c8c1636c51f5d950a5f1071a1deR29) [[3]](diffhunk://#diff-b0271f34294b21291f91445d2fb3fed9fa485abe10bf04a56dbb134749b3dd45R17)

**Configuration Normalization:**

* Updated the `normalizeShared` function in `with-native-federation.ts` to include the `pool` property in the normalized shared configuration if it is provided.

**Build Process:**

* Modified the `buildResult` function in `bundle-shared.ts` to propagate the `pool` property from the normalized shared config to the final shared info output.

**Testing:**

* Added and updated tests in `with-native-federation.spec.ts` and `bundle-shared.spec.ts` to ensure the `pool` property is correctly passed through normalization and build steps, and omitted when not configured. [[1]](diffhunk://#diff-de6da7bb65257e9e683e26f8c7f9881f5961903111f7c2e8b89fc10e6a025d61R163-R179) [[2]](diffhunk://#diff-81bcc5d3d97fe12e1b102254db1110daa46dff916f420e6a4b29b20080696d30R199-R258)