### PR TITLE
fix: Added improved support for esm detection

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -21,6 +21,18 @@ export {
   type ExportCondition,
   type ExportEntry,
 } from './lib/utils/package/package-info.js';
+export {
+  isCjsCandidate,
+  classifyByExtension,
+  hasEsmSyntax,
+  type ModuleFormat,
+} from './lib/utils/package/esm-detection.js';
+export {
+  isIdentifierName,
+  planCjsWrap,
+  buildSyntheticCjsEntry,
+  isEsmInteropError,
+} from './lib/utils/package/cjs-named-exports.js';
 
 export type {
   NfFileWatcher,

--- a/src/lib/config/remove-unused-deps.spec.ts
+++ b/src/lib/config/remove-unused-deps.spec.ts
@@ -31,6 +31,7 @@ const makeConfig = (
     denseChunking: false,
     denseExternals: false,
     integrityHashes: false,
+    synthesizeCjsExports: true,
   },
 });
 

--- a/src/lib/config/with-native-federation.spec.ts
+++ b/src/lib/config/with-native-federation.spec.ts
@@ -205,6 +205,7 @@ describe('withNativeFederation', () => {
       denseChunking: true,
       denseExternals: true,
       integrityHashes: false,
+      synthesizeCjsExports: true,
     });
   });
 

--- a/src/lib/config/with-native-federation.ts
+++ b/src/lib/config/with-native-federation.ts
@@ -35,6 +35,7 @@ export function withNativeFederation(config: FederationConfig): NormalizedFedera
       denseChunking: config.features?.denseChunking ?? false,
       denseExternals: config.features?.denseExternals ?? false,
       integrityHashes: config.features?.integrityHashes ?? false,
+      synthesizeCjsExports: config.features?.synthesizeCjsExports ?? true,
     },
     ...(config.shareScope && { shareScope: config.shareScope }),
   };

--- a/src/lib/core/build/build-for-federation.spec.ts
+++ b/src/lib/core/build/build-for-federation.spec.ts
@@ -44,6 +44,7 @@ function makeConfig(denseExternals: boolean): NormalizedFederationConfig {
       denseChunking: false,
       denseExternals,
       integrityHashes: false,
+      synthesizeCjsExports: true,
     },
   };
 }

--- a/src/lib/core/build/bundle-exposed-and-mappings.spec.ts
+++ b/src/lib/core/build/bundle-exposed-and-mappings.spec.ts
@@ -152,6 +152,7 @@ function makeConfig(overrides: Partial<NormalizedFederationConfig> = {}): Normal
       denseChunking: false,
       denseExternals: false,
       integrityHashes: false,
+      synthesizeCjsExports: true,
     },
     ...overrides,
   };

--- a/src/lib/core/build/bundle-shared.spec.ts
+++ b/src/lib/core/build/bundle-shared.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import * as crypto from 'crypto';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
@@ -136,6 +136,7 @@ function makeConfig(): NormalizedFederationConfig {
       denseChunking: false,
       denseExternals: false,
       integrityHashes: false,
+      synthesizeCjsExports: true,
     },
   };
 }
@@ -340,6 +341,116 @@ describe('bundleSharedCore (via injected io, repo and build adapter)', () => {
     expect(a).toMatch(/^foo\..{10}\.js$/);
     expect(a).toBe(await build('export const x = 1;\n')); // stable for identical content
     expect(a).not.toBe(b); // changes when content changes
+  });
+
+  it('routes a CommonJS external through a synthetic named-exports entry', async () => {
+    const mem = createMemoryIo()
+      .setFile(ROOT_PKG, '{}')
+      .setFile('/n/dayjs/dayjs.min.js', '!function(t,e){module.exports=e()}(this,function(){})');
+    const adapter = createFakeBuildAdapter({ io: mem });
+    const sharedBundles: Record<string, NormalizedExternalConfig> = {
+      dayjs: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+        version: '1.11.0',
+        chunks: false,
+        platform: 'browser',
+        build: 'default',
+        packageInfo: { entryPoint: '/n/dayjs/dayjs.min.js', version: '1.11.0', esm: false },
+      },
+    };
+
+    await bundleSharedCore(
+      {
+        io: mem,
+        repo: emptyRepo,
+        adapter,
+        evaluateModule: () => ({ isDayjs: () => {}, extend: () => {} }),
+      },
+      sharedBundles,
+      makeConfig(),
+      makeFedOptions(),
+      [],
+      BUILD_OPTIONS
+    );
+
+    const entryPoint = adapter.calls.setup[0]!.options.entryPoints[0]!;
+    // Named after the hashed outName (dayjs.<hash>.js), so packages that normalize to the
+    // same identifier can't clobber each other's synthetic entry.
+    expect(path.dirname(entryPoint.fileName)).toBe(path.join('/cache', '.nf-cjs-entries'));
+    expect(path.basename(entryPoint.fileName)).toMatch(/^dayjs\..+\.js$/);
+    const synthetic = mem.readText(entryPoint.fileName);
+    expect(synthetic).toContain('import _nfDefault from "/n/dayjs/dayjs.min.js";');
+    expect(synthetic).toContain('as isDayjs');
+  });
+
+  it('leaves a CommonJS external untouched when synthesizeCjsExports is disabled', async () => {
+    const mem = createMemoryIo()
+      .setFile(ROOT_PKG, '{}')
+      .setFile('/n/dayjs/dayjs.min.js', '!function(t,e){module.exports=e()}(this,function(){})');
+    const adapter = createFakeBuildAdapter({ io: mem });
+    const evaluate = vi.fn(() => ({ isDayjs: () => {} }));
+    const sharedBundles: Record<string, NormalizedExternalConfig> = {
+      dayjs: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^1.0.0',
+        version: '1.11.0',
+        chunks: false,
+        platform: 'browser',
+        build: 'default',
+        packageInfo: { entryPoint: '/n/dayjs/dayjs.min.js', version: '1.11.0', esm: false },
+      },
+    };
+    const config = makeConfig();
+    config.features.synthesizeCjsExports = false;
+
+    await bundleSharedCore(
+      { io: mem, repo: emptyRepo, adapter, evaluateModule: evaluate },
+      sharedBundles,
+      config,
+      makeFedOptions(),
+      [],
+      BUILD_OPTIONS
+    );
+
+    expect(evaluate).not.toHaveBeenCalled();
+    expect(adapter.calls.setup[0]!.options.entryPoints[0]!.fileName).toBe('/n/dayjs/dayjs.min.js');
+  });
+
+  it('leaves an ESM external on its original entry and never evaluates it', async () => {
+    const mem = createMemoryIo()
+      .setFile(ROOT_PKG, '{}')
+      .setFile('/n/rxjs/dist/esm/index.js', `export { Observable } from './internal/Observable';`);
+    const adapter = createFakeBuildAdapter({ io: mem });
+    const evaluate = vi.fn(() => ({}));
+    const sharedBundles: Record<string, NormalizedExternalConfig> = {
+      rxjs: {
+        singleton: true,
+        strictVersion: false,
+        requiredVersion: '^7.0.0',
+        version: '7.8.0',
+        chunks: false,
+        platform: 'browser',
+        build: 'default',
+        packageInfo: { entryPoint: '/n/rxjs/dist/esm/index.js', version: '7.8.0', esm: true },
+      },
+    };
+
+    await bundleSharedCore(
+      { io: mem, repo: emptyRepo, adapter, evaluateModule: evaluate },
+      sharedBundles,
+      makeConfig(),
+      makeFedOptions(),
+      [],
+      BUILD_OPTIONS
+    );
+
+    expect(adapter.calls.setup[0]!.options.entryPoints[0]!.fileName).toBe(
+      '/n/rxjs/dist/esm/index.js'
+    );
+    expect(evaluate).not.toHaveBeenCalled();
   });
 
   it('reuses the bundle cache when denseExternals is toggled (same output name)', async () => {

--- a/src/lib/core/build/bundle-shared.ts
+++ b/src/lib/core/build/bundle-shared.ts
@@ -28,6 +28,8 @@ import type {
   NFBuildAdapterResult,
 } from '../../domain/core/build-adapter.contract.js';
 import { getBuildAdapter } from './build-adapter.js';
+import { synthesizeCjsNamedExportsEntry, type ModuleEvaluator } from './synthesize-cjs-exports.js';
+import { createRequire } from 'module';
 
 export async function bundleShared(
   sharedBundles: Record<string, NormalizedExternalConfig>,
@@ -40,8 +42,14 @@ export async function bundleShared(
   chunks?: Record<string, string[]>;
   integrity?: IntegrityMap;
 }> {
+  const requireFromWorkspace = createRequire(path.join(fedOptions.workspaceRoot, 'index.js'));
   return bundleSharedCore(
-    { io: nodeIo, repo: sharedPackageJsonRepository, adapter: getBuildAdapter() },
+    {
+      io: nodeIo,
+      repo: sharedPackageJsonRepository,
+      adapter: getBuildAdapter(),
+      evaluateModule: (absPath: string) => requireFromWorkspace(absPath),
+    },
     sharedBundles,
     config,
     fedOptions,
@@ -54,6 +62,12 @@ interface BundleSharedDeps {
   io: IoPort;
   repo: PackageJsonRepository;
   adapter: NFBuildAdapter;
+  /**
+   * Loads a module by absolute path at build time (Node `require`) and returns its
+   * runtime exports, from which a CJS external's named exports are then enumerated.
+   * Omitted → no named-export synthesis; externals stay default-only.
+   */
+  evaluateModule?: ModuleEvaluator;
 }
 
 export async function bundleSharedCore(
@@ -76,7 +90,8 @@ export async function bundleSharedCore(
     deps.io,
     sharedBundles,
     fedOptions.dev ? '1' : '0',
-    builderVersion
+    builderVersion,
+    config.features.synthesizeCjsExports
   );
 
   const folder = fedOptions.packageJson
@@ -131,7 +146,19 @@ export async function bundleSharedCore(
   const entryPoints: EntryPoint[] = packageInfos.map(pi => {
     const encName = pi.packageName.replace(/[^A-Za-z0-9]/g, '_');
     const outName = createOutName(deps.io, pi, configState, fedOptions, encName);
-    return { fileName: pi.entryPoint, outName };
+
+    // Re-emit named exports of CommonJS externals as static exports. ESM externals are left untouched.
+    const synthetic =
+      deps.evaluateModule && config.features.synthesizeCjsExports
+        ? synthesizeCjsNamedExportsEntry(
+            deps.io,
+            deps.evaluateModule,
+            pi,
+            fedOptions.federationCache.cachePath,
+            outName
+          )
+        : null;
+    return { fileName: synthetic ?? pi.entryPoint, outName };
   });
 
   const fullOutputPath = path.join(fedOptions.workspaceRoot, fedOptions.outputPath);

--- a/src/lib/core/build/synthesize-cjs-exports.spec.ts
+++ b/src/lib/core/build/synthesize-cjs-exports.spec.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as path from 'path';
+import { synthesizeCjsNamedExportsEntry } from './synthesize-cjs-exports.js';
+import { createMemoryIo } from '../../utils/io/__test-helpers__/memory-io.js';
+import { logger } from '../../utils/logger.js';
+import type { PackageInfo } from '../../domain/utils/package-json.contract.js';
+
+const CACHE = '/cache';
+
+const pkg = (over: Partial<PackageInfo>): PackageInfo => ({
+  packageName: 'x',
+  entryPoint: '/n/x/index.js',
+  version: '1.0.0',
+  esm: false,
+  ...over,
+});
+
+describe('synthesizeCjsNamedExportsEntry', () => {
+  it('writes a synthetic entry re-exporting a CJS package’s named exports (dayjs case)', () => {
+    const io = createMemoryIo().setFile(
+      '/n/dayjs/dayjs.min.js',
+      '!function(t,e){module.exports=e()}(this,function(){})'
+    );
+    const mod = { isDayjs: () => {}, extend: () => {} };
+
+    const out = synthesizeCjsNamedExportsEntry(
+      io,
+      () => mod,
+      pkg({ packageName: 'dayjs', entryPoint: '/n/dayjs/dayjs.min.js', esm: false }),
+      CACHE,
+      'dayjs.abc123.js'
+    );
+
+    expect(out).toBe(path.join(CACHE, '.nf-cjs-entries', 'dayjs.abc123.js'));
+    const written = io.readText(out!);
+    expect(written).toContain('import _nfDefault from "/n/dayjs/dayjs.min.js";');
+    expect(written).toContain('as isDayjs');
+    expect(written).toContain('as extend');
+  });
+
+  it('skips an ESM package by metadata — never evaluates it (rxjs case)', () => {
+    const io = createMemoryIo().setFile(
+      '/n/rxjs/dist/esm/index.js',
+      `export { Observable } from './internal/Observable';`
+    );
+    const evaluate = vi.fn(() => ({}));
+
+    const out = synthesizeCjsNamedExportsEntry(
+      io,
+      evaluate,
+      pkg({ packageName: 'rxjs', entryPoint: '/n/rxjs/dist/esm/index.js', esm: true }),
+      CACHE,
+      'rxjs'
+    );
+
+    expect(out).toBeNull();
+    expect(evaluate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to default-only (null) and warns when a CJS require() genuinely fails', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const io = createMemoryIo().setFile(
+      '/n/broken/index.js',
+      '!function(){module.exports={}}()'
+    );
+
+    const out = synthesizeCjsNamedExportsEntry(
+      io,
+      () => {
+        throw new ReferenceError('window is not defined');
+      },
+      pkg({ packageName: 'broken', entryPoint: '/n/broken/index.js', esm: false }),
+      CACHE,
+      'broken'
+    );
+
+    expect(out).toBeNull();
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
+  it('falls back silently (null, no warning) when require() fails because the file was ESM', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const io = createMemoryIo().setFile('/n/esm-cjs/index.cjs', 'module.exports={}');
+
+    const out = synthesizeCjsNamedExportsEntry(
+      io,
+      () => {
+        const err = new Error('require of ES module') as Error & { code: string };
+        err.code = 'ERR_REQUIRE_ESM';
+        throw err;
+      },
+      pkg({ packageName: 'esm-cjs', entryPoint: '/n/esm-cjs/index.cjs', esm: false }),
+      CACHE,
+      'esm_cjs'
+    );
+
+    expect(out).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('returns null (leaves the original entry) when there are no names to wrap', () => {
+    const io = createMemoryIo().setFile('/n/x/index.js', 'module.exports=function(){}');
+    const out = synthesizeCjsNamedExportsEntry(io, () => () => {}, pkg({}), CACHE, 'x');
+    expect(out).toBeNull();
+  });
+});

--- a/src/lib/core/build/synthesize-cjs-exports.ts
+++ b/src/lib/core/build/synthesize-cjs-exports.ts
@@ -1,0 +1,86 @@
+import * as path from 'path';
+import type { IoPort } from '../../domain/utils/io-port.contract.js';
+import type { PackageInfo } from '../../domain/utils/package-json.contract.js';
+import { logger } from '../../utils/logger.js';
+import { isCjsCandidate } from '../../utils/package/esm-detection.js';
+import {
+  planCjsWrap,
+  buildSyntheticCjsEntry,
+  isEsmInteropError,
+} from '../../utils/package/cjs-named-exports.js';
+
+/** Evaluates a module at build time (Node `require`) and returns its value, or throws. */
+export type ModuleEvaluator = (absPath: string) => unknown;
+
+const SYNTHETIC_DIR = '.nf-cjs-entries';
+const warned = new Set<string>();
+
+/** Nearest package.json `type`, walking up from `fromDir` (Node's rule). */
+function nearestPackageType(io: IoPort, fromDir: string): 'module' | 'commonjs' | undefined {
+  let dir = fromDir;
+  for (;;) {
+    const pkg = path.join(dir, 'package.json');
+    if (io.exists(pkg)) {
+      try {
+        const type = JSON.parse(io.readText(pkg))?.type;
+        return type === 'module' || type === 'commonjs' ? type : undefined;
+      } catch {
+        // Unparseable: keep walking up.
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+/**
+ * For a CommonJS shared external, `require()`s it, enumerates its runtime named
+ * exports, and writes a synthetic ESM entry re-exporting them.
+ *
+ * Returns the synthetic entry path, or `null` to keep the original entry (not a CJS
+ * candidate, no names to wrap, or a `require()` failure → default-only fallback).
+ */
+export function synthesizeCjsNamedExportsEntry(
+  io: IoPort,
+  evaluateModule: ModuleEvaluator,
+  pi: PackageInfo,
+  cachePath: string,
+  outName: string
+): string | null {
+  const entryPoint = pi.entryPoint;
+
+  const candidate = isCjsCandidate({
+    esm: pi.esm,
+    entryPoint,
+    packageType: nearestPackageType(io, path.dirname(entryPoint)),
+    readSource: () => io.readText(entryPoint),
+  });
+  if (!candidate) return null;
+
+  let plan: { wrap: boolean; keys: string[] };
+  try {
+    plan = planCjsWrap(evaluateModule(entryPoint));
+  } catch (err) {
+    if (!isEsmInteropError(err) && !warned.has(entryPoint)) {
+      warned.add(entryPoint);
+      const detail = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        `[native-federation] Could not enumerate named exports of "${entryPoint}" at build ` +
+          `time (${detail}); falling back to default-only. Named imports from this package ` +
+          `may fail across the module boundary.`
+      );
+    }
+    return null;
+  }
+
+  if (!plan.wrap) return null;
+
+  const dir = path.join(cachePath, SYNTHETIC_DIR);
+  io.mkdirp(dir);
+  // Name the synthetic entry after `outName` (version + entry + config hash) so two shared
+  // packages whose names normalize to the same identifier can't clobber each other's entry.
+  const syntheticPath = path.join(dir, outName);
+  io.writeText(syntheticPath, buildSyntheticCjsEntry(entryPoint, plan.keys));
+  return syntheticPath;
+}

--- a/src/lib/core/cache/cache-persistence.spec.ts
+++ b/src/lib/core/cache/cache-persistence.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import * as crypto from 'crypto';
-import { cacheEntryCore, getChecksumCore, getFilename, type CacheMetadata } from './cache-persistence.js';
+import {
+  cacheEntryCore,
+  getChecksumCore,
+  getFilename,
+  type CacheMetadata,
+} from './cache-persistence.js';
 import { createMemoryIo } from '../../utils/io/__test-helpers__/memory-io.js';
 import { logger } from '../../utils/logger.js';
 import type { NormalizedExternalConfig } from '../../domain/config/external-config.contract.js';
@@ -51,10 +56,17 @@ describe('getChecksumCore', () => {
     );
   });
 
+  it('changes when the CJS-export synthesis flag changes', () => {
+    const base = { react: ext('18') };
+    expect(getChecksumCore(io, base, '0', '1.0.0', true)).not.toBe(
+      getChecksumCore(io, base, '0', '1.0.0', false)
+    );
+  });
+
   it('matches a hand-computed sha256', () => {
     const expected = crypto
       .createHash('sha256')
-      .update('deps:react@18:dev=0:builder=2.0.0')
+      .update('deps:react@18:dev=0:builder=2.0.0:cjs=1')
       .digest('hex');
     expect(getChecksumCore(io, { react: ext('18') }, '0', '2.0.0')).toBe(expected);
   });

--- a/src/lib/core/cache/cache-persistence.ts
+++ b/src/lib/core/cache/cache-persistence.ts
@@ -24,14 +24,16 @@ export const getFilename = (title: string, dev?: boolean) => {
 export const getChecksum = (
   shared: Record<string, NormalizedExternalConfig>,
   dev: '1' | '0',
-  builderVersion = ''
-): string => getChecksumCore(nodeIo, shared, dev, builderVersion);
+  builderVersion = '',
+  synthesizeCjsExports = true
+): string => getChecksumCore(nodeIo, shared, dev, builderVersion, synthesizeCjsExports);
 
 export const getChecksumCore = (
   hash: HashPort,
   shared: Record<string, NormalizedExternalConfig>,
   dev: '1' | '0',
-  builderVersion = ''
+  builderVersion = '',
+  synthesizeCjsExports = true
 ): string => {
   const denseExternals = Object.keys(shared)
     .sort()
@@ -41,7 +43,10 @@ export const getChecksumCore = (
       );
     }, 'deps');
 
-  return hash.hash('sha256', denseExternals + `:dev=${dev}:builder=${builderVersion}`).hex();
+  const cjs = synthesizeCjsExports ? '1' : '0';
+  return hash
+    .hash('sha256', denseExternals + `:dev=${dev}:builder=${builderVersion}:cjs=${cjs}`)
+    .hex();
 };
 
 export type CacheMetadata = {

--- a/src/lib/core/normalize-options.spec.ts
+++ b/src/lib/core/normalize-options.spec.ts
@@ -40,6 +40,7 @@ function makeConfig(
       denseChunking: false,
       denseExternals: false,
       integrityHashes: false,
+      synthesizeCjsExports: true,
     },
     ...overrides,
   };

--- a/src/lib/domain/config/federation-config.contract.ts
+++ b/src/lib/domain/config/federation-config.contract.ts
@@ -23,6 +23,7 @@ export interface FederationConfig {
     denseChunking?: boolean;
     denseExternals?: boolean;
     integrityHashes?: boolean;
+    synthesizeCjsExports?: boolean;
   };
 }
 
@@ -42,5 +43,6 @@ export interface NormalizedFederationConfig {
     denseChunking: boolean;
     denseExternals: boolean;
     integrityHashes: boolean;
+    synthesizeCjsExports: boolean;
   };
 }

--- a/src/lib/utils/package/cjs-named-exports.spec.ts
+++ b/src/lib/utils/package/cjs-named-exports.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isIdentifierName,
+  planCjsWrap,
+  buildSyntheticCjsEntry,
+  isEsmInteropError,
+} from './cjs-named-exports.js';
+
+describe('isIdentifierName', () => {
+  it('accepts valid identifiers and rejects the rest', () => {
+    for (const ok of ['isDayjs', '_x', '$', 'a1']) expect(isIdentifierName(ok)).toBe(true);
+    for (const bad of ['1a', 'a-b', 'a.b', '', 'a b']) expect(isIdentifierName(bad)).toBe(false);
+  });
+});
+
+describe('planCjsWrap', () => {
+  it('wraps a CJS object, dropping default/__esModule and non-identifier keys', () => {
+    const plan = planCjsWrap({ isDayjs: () => {}, extend: () => {}, default: 1, '0bad': 1 });
+    expect(plan.wrap).toBe(true);
+    expect(plan.keys.sort()).toEqual(['extend', 'isDayjs']);
+  });
+
+  it('does not wrap ES-module namespaces', () => {
+    const ns = { foo: 1 } as Record<PropertyKey, unknown>;
+    ns[Symbol.toStringTag] = 'Module';
+    expect(planCjsWrap(ns).wrap).toBe(false);
+  });
+
+  it('does not wrap __esModule interop objects', () => {
+    expect(planCjsWrap({ __esModule: true, foo: 1 }).wrap).toBe(false);
+  });
+
+  it('does not wrap primitives, null, or objects with no extra keys', () => {
+    expect(planCjsWrap(null).wrap).toBe(false);
+    expect(planCjsWrap(42).wrap).toBe(false);
+    expect(planCjsWrap({ default: 1 }).wrap).toBe(false);
+  });
+});
+
+describe('buildSyntheticCjsEntry', () => {
+  it('re-exports default plus each name via an alias clause', () => {
+    const out = buildSyntheticCjsEntry('/n/dayjs/dayjs.min.js', ['isDayjs', 'extend']);
+    expect(out).toContain(`import _nfDefault from "/n/dayjs/dayjs.min.js";`);
+    expect(out).toContain(`export default _nfDefault;`);
+    expect(out).toContain(`const _nf0 = _nfDefault["isDayjs"];`);
+    expect(out).toContain(`export { _nf0 as isDayjs, _nf1 as extend };`);
+  });
+
+  it('emits default-only when there are no names', () => {
+    const out = buildSyntheticCjsEntry('/n/x/index.js', []);
+    expect(out).toContain('export default _nfDefault;');
+    expect(out).not.toContain('export {');
+  });
+});
+
+describe('isEsmInteropError', () => {
+  it('recognises ESM require errors', () => {
+    expect(isEsmInteropError({ code: 'ERR_REQUIRE_ESM' })).toBe(true);
+    expect(isEsmInteropError({ code: 'ERR_REQUIRE_ASYNC_MODULE' })).toBe(true);
+    expect(isEsmInteropError(new SyntaxError('Unexpected token \'export\''))).toBe(true);
+  });
+
+  it('does not treat genuine failures as ESM interop', () => {
+    expect(isEsmInteropError(new ReferenceError('window is not defined'))).toBe(false);
+    expect(isEsmInteropError({ code: 'ERR_MODULE_NOT_FOUND' })).toBe(false);
+  });
+});

--- a/src/lib/utils/package/cjs-named-exports.ts
+++ b/src/lib/utils/package/cjs-named-exports.ts
@@ -1,0 +1,55 @@
+/** A key is re-exportable only if it is a syntactically valid identifier name. */
+export const isIdentifierName = (name: string): boolean =>
+  /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name);
+
+/**
+ * Decides whether a `require()`d CommonJS value needs a synthetic named-export
+ * wrapper, and which names to re-export. UMD/CJS packages (e.g. dayjs) assign
+ * named exports dynamically, invisible to static lexers; enumerating the value
+ * recovers them. ES-module namespaces and `__esModule` interop objects are
+ * skipped — a bundler already exposes those statically.
+ */
+export const planCjsWrap = (mod: unknown): { wrap: boolean; keys: string[] } => {
+  if (mod === null || (typeof mod !== 'object' && typeof mod !== 'function')) {
+    return { wrap: false, keys: [] };
+  }
+  if ((mod as Record<PropertyKey, unknown>)[Symbol.toStringTag] === 'Module') {
+    return { wrap: false, keys: [] };
+  }
+  if ((mod as Record<string, unknown>)['__esModule']) {
+    return { wrap: false, keys: [] };
+  }
+
+  const keys = Object.keys(mod as object).filter(
+    key => key !== 'default' && key !== '__esModule' && isIdentifierName(key)
+  );
+
+  return { wrap: keys.length > 0, keys };
+};
+
+/**
+ * Synthetic ESM entry re-exporting the CommonJS default plus each discovered name.
+ * The `export { local as key }` clause lets reserved-word keys (`class`, `default`)
+ * pass without escaping.
+ */
+export const buildSyntheticCjsEntry = (importPath: string, keys: string[]): string => {
+  const spec = JSON.stringify(importPath);
+  const lines = [`import _nfDefault from ${spec};`, `export default _nfDefault;`];
+
+  if (keys.length > 0) {
+    keys.forEach((key, i) => lines.push(`const _nf${i} = _nfDefault[${JSON.stringify(key)}];`));
+    lines.push(`export { ${keys.map((key, i) => `_nf${i} as ${key}`).join(', ')} };`);
+  }
+
+  return lines.join('\n') + '\n';
+};
+
+/** True when a `require()` failure just means the file was ESM after all. */
+export const isEsmInteropError = (err: unknown): boolean => {
+  const code = (err as { code?: string } | null)?.code;
+  if (code === 'ERR_REQUIRE_ESM' || code === 'ERR_REQUIRE_ASYNC_MODULE') return true;
+  return (
+    err instanceof SyntaxError &&
+    /Unexpected token 'export'|Cannot use import statement|export|import statement/.test(err.message)
+  );
+};

--- a/src/lib/utils/package/esm-detection.spec.ts
+++ b/src/lib/utils/package/esm-detection.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isESMExport } from './esm-detection.js';
+import { isESMExport, classifyByExtension, hasEsmSyntax, isCjsCandidate } from './esm-detection.js';
 
 describe('isESMExport', () => {
   it('classifies known ESM conditions as true', () => {
@@ -18,5 +18,74 @@ describe('isESMExport', () => {
     for (const e of ['default', 'types', 'node', 'browser']) {
       expect(isESMExport(e)).toBeUndefined();
     }
+  });
+});
+
+describe('classifyByExtension', () => {
+  it('maps extensions to formats', () => {
+    expect(classifyByExtension('/a/index.mjs')).toBe('esm');
+    expect(classifyByExtension('/a/index.cjs')).toBe('cjs');
+    expect(classifyByExtension('/a/index.js')).toBe('unknown');
+  });
+
+  it('treats unknown/extensionless entries as esm (never blindly required)', () => {
+    expect(classifyByExtension('/a/index')).toBe('esm');
+    expect(classifyByExtension('/a/index.json')).toBe('esm');
+  });
+});
+
+describe('hasEsmSyntax', () => {
+  it('detects top-level export/import statements', () => {
+    expect(hasEsmSyntax(`export { Observable } from './internal/Observable';`)).toBe(true);
+    expect(hasEsmSyntax(`export default foo;`)).toBe(true);
+    expect(hasEsmSyntax(`import x from 'y';`)).toBe(true);
+    expect(hasEsmSyntax(`export{a};import"b"`)).toBe(true);
+  });
+
+  it('does not flag CommonJS/UMD or dynamic import as ESM', () => {
+    expect(hasEsmSyntax(`!function(t,e){module.exports=e()}(this,function(){return {}})`)).toBe(
+      false
+    );
+    expect(hasEsmSyntax(`const m = await import('x');`)).toBe(false);
+  });
+});
+
+describe('isCjsCandidate', () => {
+  it('excludes ESM by metadata even when the entry is a plain .js (rxjs case)', () => {
+    expect(
+      isCjsCandidate({
+        esm: true,
+        entryPoint: '/n/rxjs/dist/esm/index.js',
+        readSource: () => `export { Observable } from './internal/Observable';`,
+      })
+    ).toBe(false);
+  });
+
+  it('includes a UMD .js with no ESM metadata (dayjs case)', () => {
+    expect(
+      isCjsCandidate({
+        esm: false,
+        entryPoint: '/n/dayjs/dayjs.min.js',
+        readSource: () => `!function(t,e){module.exports=e()}(this,function(){})`,
+      })
+    ).toBe(true);
+  });
+
+  it('excludes ambiguous .js when its source is ESM, even without metadata', () => {
+    expect(
+      isCjsCandidate({
+        entryPoint: '/n/pkg/index.js',
+        readSource: () => `export const x = 1;`,
+      })
+    ).toBe(false);
+  });
+
+  it('excludes ambiguous .js under a type:module package', () => {
+    expect(isCjsCandidate({ entryPoint: '/n/pkg/index.js', packageType: 'module' })).toBe(false);
+  });
+
+  it('classifies by extension: .mjs → excluded, .cjs → included', () => {
+    expect(isCjsCandidate({ entryPoint: '/n/pkg/index.mjs' })).toBe(false);
+    expect(isCjsCandidate({ entryPoint: '/n/pkg/index.cjs' })).toBe(true);
   });
 });

--- a/src/lib/utils/package/esm-detection.ts
+++ b/src/lib/utils/package/esm-detection.ts
@@ -11,3 +11,47 @@ export const isESMExport = (e: string): boolean | undefined => {
 
   return undefined;
 };
+
+export type ModuleFormat = 'esm' | 'cjs' | 'unknown';
+
+/** Node's format rule keyed on extension alone; `.js` stays ambiguous. */
+export const classifyByExtension = (entryPoint: string): ModuleFormat => {
+  if (entryPoint.endsWith('.mjs')) return 'esm';
+  if (entryPoint.endsWith('.cjs')) return 'cjs';
+  if (entryPoint.endsWith('.js')) return 'unknown';
+  return 'esm';
+};
+
+/** Does the source contain top-level ESM `import`/`export`? Dynamic `import()` is excluded (legal in CJS). */
+export const hasEsmSyntax = (source: string): boolean => {
+  const head = source.slice(0, 16_384);
+  const exportStmt =
+    /(?:^|[;\n}])\s*export\s*(?:\{|\*|default\b|const\b|let\b|var\b|function\b|async\b|class\b)/;
+  const importStmt = /(?:^|[;\n}])\s*import\s*(?:[A-Za-z_$]|\{|\*|['"])/;
+  return exportStmt.test(head) || importStmt.test(head);
+};
+
+export const isCjsCandidate = (input: {
+  esm?: boolean;
+  entryPoint: string;
+  /** Nearest package.json `type` for an ambiguous `.js`. */
+  packageType?: 'module' | 'commonjs';
+  /** Lazy source for fallback content sniff; only read for an ambiguous `.js`. */
+  readSource?: () => string;
+}): boolean => {
+  if (input.esm === true) return false;
+
+  const fmt = classifyByExtension(input.entryPoint);
+  if (fmt === 'esm') return false;
+  if (fmt === 'cjs') return true;
+
+  if (input.packageType === 'module') return false;
+  if (input.readSource) {
+    try {
+      if (hasEsmSyntax(input.readSource())) return false;
+    } catch {
+      // Unreadable: the guarded build-time require() at the call site still backstops a wrong guess.
+    }
+  }
+  return true;
+};


### PR DESCRIPTION
Linked to https://github.com/native-federation/angular-adapter/pull/89

This pull request introduces support for synthesizing named exports for CommonJS externals in the module federation build process. The main feature is a new `synthesizeCjsExports` option, which, when enabled, will automatically generate ESM wrapper entries for CommonJS dependencies, making their named exports available to consumers. The implementation includes logic for detecting CJS candidates, evaluating their exports at build time, and writing synthetic entry files. Additionally, the cache checksum logic and relevant tests have been updated to account for this new feature.

**New CommonJS named exports synthesis:**

* Added the `synthesizeCjsExports` feature flag to federation config and all related test configs, defaulting to `true`. [[1]](diffhunk://#diff-0145156610c0e66ec0e16b3c5b8142858da7cda1c7523c1fae90cada86d7617cR26) [[2]](diffhunk://#diff-88e9d4be12118e423be750f3f3cbadbd6c645bc1a401fea2634c53caa30a0229R38) [[3]](diffhunk://#diff-44ee46a2763e6d86137fff1e0233b5b9860bc7237ec9f7bd02e867cba1c7584cR34) [[4]](diffhunk://#diff-de6da7bb65257e9e683e26f8c7f9881f5961903111f7c2e8b89fc10e6a025d61R208) [[5]](diffhunk://#diff-3184e92b59f27314aafbc3657fb42ad020f5220343809c37a83adf9399a74f1aR47) [[6]](diffhunk://#diff-19f7e09c718ecf8847da58742ad0f1d1dc5dd1d8158dd2bc1e162cb4c5f78274R155) [[7]](diffhunk://#diff-81bcc5d3d97fe12e1b102254db1110daa46dff916f420e6a4b29b20080696d30R139) [[8]](diffhunk://#diff-2df48fb3ac2cad9ea20c2173e611bc8d3b79d4a4229300768009e4bf47475762R43)
* Implemented the `synthesizeCjsNamedExportsEntry` function in `synthesize-cjs-exports.ts`, which creates synthetic ESM entries for CJS externals by evaluating their exports at build time.
* Updated `bundleSharedCore` to use this function and route CJS externals through the synthetic entry when enabled. [[1]](diffhunk://#diff-af77c096b4deddec353d29e8e28671d0abb39bb8365be8f79aa47bd318c64c0fR31-R32) [[2]](diffhunk://#diff-af77c096b4deddec353d29e8e28671d0abb39bb8365be8f79aa47bd318c64c0fR65-R70) [[3]](diffhunk://#diff-af77c096b4deddec353d29e8e28671d0abb39bb8365be8f79aa47bd318c64c0fL134-R161)
* Extended the test suite with cases for CJS named export synthesis, ESM externals, and error handling. [[1]](diffhunk://#diff-81bcc5d3d97fe12e1b102254db1110daa46dff916f420e6a4b29b20080696d30R346-R455) [[2]](diffhunk://#diff-dfb6151f42d42b9687ea055d202cece96db870a41cff420acd558d25a08f7bd1R1-R108)

**Cache logic updates:**

* Modified the cache checksum calculation to include the `synthesizeCjsExports` flag, ensuring cache correctness when toggling the feature. [[1]](diffhunk://#diff-e000eda5b0e4baba1574c568d871923c41393b6a8ce5a5e3b26e98719f96b10dL27-R36) [[2]](diffhunk://#diff-e000eda5b0e4baba1574c568d871923c41393b6a8ce5a5e3b26e98719f96b10dL44-R49) [[3]](diffhunk://#diff-047f3221d5d58b2417deb9a74cfdfd76c912729743e01ebc19079d2db89f3fecR59-R69)

**Exports and internal API:**

* Re-exported new helpers (`isCjsCandidate`, `classifyByExtension`, etc.) from the internal API for use in other parts of the codebase.