### PR TITLE
fix: Support for 'npm link' shared libraries

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -39,3 +39,4 @@ export type {
   NfFileWatcherOptions,
 } from './lib/domain/utils/file-watcher.contract.js';
 export { syncNfFileWatcher, createNfWatcher } from './lib/utils/file-watcher.js';
+export { linkedSharedDirs } from './lib/core/build/resolve-shared-dirs.js';

--- a/src/lib/core/build/build-for-federation.ts
+++ b/src/lib/core/build/build-for-federation.ts
@@ -1,9 +1,4 @@
-import type {
-  ChunkInfo,
-  FederationInfo,
-  IntegrityMap,
-  SharedInfo,
-} from '../../domain/core/federation-info.contract.js';
+import type { FederationInfo } from '../../domain/core/federation-info.contract.js';
 import {
   bundleExposedAndMappings,
   describeExposed,
@@ -15,11 +10,10 @@ import { densifyExternals } from '../output/densify-externals.js';
 import { writeFederationInfo } from '../output/write-federation-info.js';
 import { writeImportMap } from '../output/write-import-map.js';
 import { logger } from '../../utils/logger.js';
-import { inferPackageFromSecondary, normalizePackageName } from '../../utils/normalize.js';
 import { AbortedError } from '../../utils/errors.js';
 import type { NormalizedFederationConfig } from '../../domain/config/federation-config.contract.js';
-import type { NormalizedExternalConfig } from '../../domain/config/external-config.contract.js';
 import { addExternalsToCache } from '../cache/federation-cache.js';
+import { planSharedBundles, type SharedBundlePlan } from './shared-bundle-plan.js';
 import path from 'path';
 
 export async function buildForFederation(
@@ -37,81 +31,7 @@ export async function buildForFederation(
   logger.notice("Skip packages you don't want to share in your federation config");
 
   // 2. Externals
-  const { sharedBrowser, sharedServer, separateBrowser, separateServer } = splitShared(
-    config.shared
-  );
-
-  if (Object.keys(sharedBrowser).length > 0) {
-    logger.info(`Bundling external npm packages with bundle type 'browser-shared'`);
-    const start = process.hrtime();
-
-    const sharedPackageInfoBrowser = await bundleShared(
-      sharedBrowser,
-      config,
-      fedOptions,
-      externals,
-      { platform: 'browser', bundleName: 'browser-shared', chunks: config.chunks }
-    );
-
-    logger.measure(start, 'Step 2.1) Bundling all shared browser externals');
-
-    addExternalsToCache(fedOptions.federationCache, sharedPackageInfoBrowser);
-
-    if (signal?.aborted) throw new AbortedError('[buildForFederation] After shared-browser bundle');
-  }
-
-  if (Object.keys(sharedServer).length > 0) {
-    logger.info(`Bundling external npm packages with bundle type 'server-shared'`);
-    const start = process.hrtime();
-
-    const sharedPackageInfoServer = await bundleShared(
-      sharedServer,
-      config,
-      fedOptions,
-      externals,
-      { platform: 'node', bundleName: 'node-shared', chunks: config.chunks }
-    );
-    logger.measure(start, 'Step 2.1) Bundling all shared node externals');
-
-    addExternalsToCache(fedOptions.federationCache, sharedPackageInfoServer);
-
-    if (signal?.aborted) throw new AbortedError('[buildForFederation] After shared-node bundle');
-  }
-
-  if (Object.keys(separateBrowser).length > 0) {
-    logger.info(`Bundling external npm packages with bundle type 'browser-separate'`);
-
-    const start = process.hrtime();
-    const separatePackageInfoBrowser = await bundleSeparatePackages(
-      separateBrowser,
-      externals,
-      config,
-      fedOptions,
-      { platform: 'browser' }
-    );
-    logger.measure(start, 'Step 2.2) Bundling all separate browser external packages');
-    addExternalsToCache(fedOptions.federationCache, separatePackageInfoBrowser);
-    if (signal?.aborted)
-      throw new AbortedError('[buildForFederation] After separate-browser bundle');
-  }
-
-  if (Object.keys(separateServer).length > 0) {
-    logger.info(`Bundling external npm packages with bundle type 'node-separate'`);
-
-    const start = process.hrtime();
-    const separatePackageInfoServer = await bundleSeparatePackages(
-      separateServer,
-      externals,
-      config,
-      fedOptions,
-      { platform: 'node' }
-    );
-
-    logger.measure(start, 'Step 2.2) Bundling all separate node external packages');
-    addExternalsToCache(fedOptions.federationCache, separatePackageInfoServer);
-  }
-
-  if (signal?.aborted) throw new AbortedError('[buildForFederation] After separate-node bundle');
+  await executeSharedBundlePlans(planSharedBundles(config, externals), config, fedOptions, signal);
 
   // 2. Shared mappings and exposed modules
   const start = process.hrtime();
@@ -176,108 +96,49 @@ export async function buildForFederation(
   return federationInfo;
 }
 
-type SplitSharedResult = {
-  sharedServer: Record<string, NormalizedExternalConfig>;
-  sharedBrowser: Record<string, NormalizedExternalConfig>;
-  separateBrowser: Record<string, NormalizedExternalConfig>;
-  separateServer: Record<string, NormalizedExternalConfig>;
-};
-
-async function bundleSeparatePackages(
-  separateBrowser: Record<string, NormalizedExternalConfig>,
-  externals: string[],
+/**
+ * Bundles shared/separate externals per plan and populates the federation cache.
+ * Shared bundles run sequentially (with signal checks); separate bundles run in
+ * parallel. Shared by the initial build and the watch rebuild.
+ */
+export async function executeSharedBundlePlans(
+  plans: SharedBundlePlan[],
   config: NormalizedFederationConfig,
   fedOptions: NormalizedFederationOptions,
-  buildOptions: { platform: 'browser' | 'node' }
-) {
-  const groupedByPackage: Record<
-    string,
-    {
-      entries: Record<string, NormalizedExternalConfig>;
-      chunks: boolean;
-    }
-  > = {};
+  signal?: AbortSignal
+): Promise<void> {
+  for (const plan of plans.filter(p => p.kind === 'shared')) {
+    logger.info(`Bundling external npm packages with bundle type '${plan.bundleName}'`);
+    const start = process.hrtime();
 
-  for (const [key, shared] of Object.entries(separateBrowser)) {
-    const packageName = shared.build === 'separate' ? key : inferPackageFromSecondary(key);
-    if (!groupedByPackage[packageName]) {
-      groupedByPackage[packageName] = {
-        chunks: shared.chunks,
-        entries: {},
-      };
-    }
-    groupedByPackage[packageName].entries[key] = shared;
+    const info = await bundleShared(plan.entries, config, fedOptions, plan.externals, {
+      platform: plan.platform,
+      bundleName: plan.bundleName,
+      chunks: plan.chunks,
+    });
+
+    logger.measure(start, `Step 2.1) Bundling '${plan.bundleName}' externals`);
+    addExternalsToCache(fedOptions.federationCache, info);
+
+    if (signal?.aborted)
+      throw new AbortedError(`[buildForFederation] After ${plan.bundleName} bundle`);
   }
 
-  const bundlePromises = Object.entries(groupedByPackage).map(
-    async ([packageName, packageConfig]) => {
-      return bundleShared(
-        packageConfig.entries,
-        config,
-        fedOptions,
-        externals.filter(e => !e.startsWith(packageName)),
-        {
-          platform: buildOptions.platform,
-          chunks: packageConfig.chunks,
-          bundleName: `${buildOptions.platform}-${normalizePackageName(packageName)}`,
-        }
-      );
-    }
-  );
+  const separatePlans = plans.filter(p => p.kind === 'separate');
+  if (separatePlans.length > 0) {
+    const start = process.hrtime();
+    const results = await Promise.all(
+      separatePlans.map(plan =>
+        bundleShared(plan.entries, config, fedOptions, plan.externals, {
+          platform: plan.platform,
+          bundleName: plan.bundleName,
+          chunks: plan.chunks,
+        })
+      )
+    );
+    logger.measure(start, 'Step 2.2) Bundling all separate external packages');
+    for (const info of results) addExternalsToCache(fedOptions.federationCache, info);
 
-  const buildResults = await Promise.all(bundlePromises);
-  return buildResults.reduce(
-    (acc, r) => {
-      let chunks = acc.chunks;
-      if (r.chunks) {
-        chunks = { ...(acc.chunks ?? {}), ...r.chunks };
-      }
-      let integrity = acc.integrity;
-      if (r.integrity) {
-        integrity = { ...(acc.integrity ?? {}), ...r.integrity };
-      }
-      return {
-        externals: [...acc.externals, ...r.externals],
-        chunks,
-        integrity,
-      };
-    },
-    { externals: [] } as {
-      externals: SharedInfo[];
-      chunks?: ChunkInfo;
-      integrity?: IntegrityMap;
-    }
-  );
-}
-
-function splitShared(shared: Record<string, NormalizedExternalConfig>): SplitSharedResult {
-  const sharedServer: Record<string, NormalizedExternalConfig> = {};
-  const sharedBrowser: Record<string, NormalizedExternalConfig> = {};
-  const separateBrowser: Record<string, NormalizedExternalConfig> = {};
-  const separateServer: Record<string, NormalizedExternalConfig> = {};
-
-  for (const key in shared) {
-    const obj = shared[key];
-
-    if (obj?.platform === 'node') {
-      if (obj.build === 'default') {
-        sharedServer[key] = obj;
-      } else {
-        separateServer[key] = obj;
-      }
-    } else if (obj?.platform === 'browser') {
-      if (obj.build === 'default') {
-        sharedBrowser[key] = obj;
-      } else {
-        separateBrowser[key] = obj;
-      }
-    }
+    if (signal?.aborted) throw new AbortedError('[buildForFederation] After separate bundle');
   }
-
-  return {
-    sharedBrowser,
-    sharedServer,
-    separateBrowser,
-    separateServer,
-  };
 }

--- a/src/lib/core/build/bundle-shared.ts
+++ b/src/lib/core/build/bundle-shared.ts
@@ -19,6 +19,7 @@ import { DEFAULT_EXTERNAL_LIST } from './default-external-list.js';
 import { isSourceFile, transformChunkImports } from './rewrite-chunk-imports.js';
 import { toChunkImport } from '../../domain/core/chunk.js';
 import { cacheEntryCore, getChecksumCore, getFilename } from '../cache/cache-persistence.js';
+import { linkedContentSignals } from './resolve-shared-dirs.js';
 import { computeIntegrityMapCore } from './compute-integrity.js';
 import { fileURLToPath } from 'url';
 import type { NormalizedExternalConfig } from '../../domain/config/external-config.contract.js';
@@ -86,17 +87,25 @@ export async function bundleSharedCore(
   const builderPackageJson = readBuilderPackageJson(deps.io, fileURLToPath(import.meta.url));
   const builderVersion = parseBuilderVersion(builderPackageJson);
 
+  const folder = fedOptions.packageJson
+    ? path.dirname(fedOptions.packageJson)
+    : fedOptions.workspaceRoot;
+
+  const contentSignals = linkedContentSignals(
+    Object.keys(sharedBundles),
+    folder,
+    deps.io,
+    deps.repo
+  );
+
   const checksum = getChecksumCore(
     deps.io,
     sharedBundles,
     fedOptions.dev ? '1' : '0',
     builderVersion,
-    config.features.synthesizeCjsExports
+    config.features.synthesizeCjsExports,
+    contentSignals
   );
-
-  const folder = fedOptions.packageJson
-    ? path.dirname(fedOptions.packageJson)
-    : fedOptions.workspaceRoot;
 
   const bundleCache = cacheEntryCore(
     deps.io,
@@ -145,7 +154,14 @@ export async function bundleSharedCore(
 
   const entryPoints: EntryPoint[] = packageInfos.map(pi => {
     const encName = pi.packageName.replace(/[^A-Za-z0-9]/g, '_');
-    const outName = createOutName(deps.io, pi, configState, fedOptions, encName);
+    const outName = createOutName(
+      deps.io,
+      pi,
+      configState,
+      fedOptions,
+      encName,
+      contentSignals[pi.packageName] ?? ''
+    );
 
     // Re-emit named exports of CommonJS externals as static exports. ESM externals are left untouched.
     const synthetic =
@@ -327,9 +343,11 @@ function createOutName(
   pi: PackageInfo,
   configState: string,
   fedOptions: NormalizedFederationOptions,
-  encName: string
+  encName: string,
+  contentSignal = ''
 ) {
-  const hashBase = pi.version + '_' + pi.entryPoint + '_' + configState;
+  const hashBase =
+    pi.version + '_' + pi.entryPoint + '_' + configState + (contentSignal ? '_' + contentSignal : '');
   const hash = calcHashCore(io, hashBase);
 
   const outName = fedOptions.dev ? `${encName}.${hash}-dev.js` : `${encName}.${hash}.js`;

--- a/src/lib/core/build/rebuild-affected-externals.spec.ts
+++ b/src/lib/core/build/rebuild-affected-externals.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createMemoryIo } from '../../utils/io/__test-helpers__/memory-io.js';
+import type { NormalizedFederationConfig } from '../../domain/config/federation-config.contract.js';
+import type { NormalizedExternalConfig } from '../../domain/config/external-config.contract.js';
+import type { NormalizedFederationOptions } from '../../domain/core/federation-options.contract.js';
+import type { SharedInfo } from '../../domain/core/federation-info.contract.js';
+import type { PackageJsonRepository } from '../../domain/utils/package-json.contract.js';
+
+// Only the bundling leaf is mocked (it is nodeIo-bound and not port-injected);
+// resolveSharedPackageDirs / affectedSharedKeys / cacheEntryCore all run for real
+// against the injected memory-io, so this exercises the actual resolution path.
+vi.mock('./build-for-federation.js', () => ({
+  executeSharedBundlePlans: vi.fn(async (_plans, _config, fedOptions: NormalizedFederationOptions) => {
+    fedOptions.federationCache.externals.push({
+      packageName: 'a',
+      outFileName: 'a.fresh.js',
+    } as SharedInfo);
+  }),
+}));
+
+const { rebuildAffectedExternals } = await import('./rebuild-for-federation.js');
+const { executeSharedBundlePlans } = await import('./build-for-federation.js');
+
+function config(): NormalizedFederationConfig {
+  return {
+    name: 'app',
+    chunks: false,
+    shared: {
+      a: { platform: 'browser', build: 'default', chunks: false } as NormalizedExternalConfig,
+    },
+    features: {},
+  } as unknown as NormalizedFederationConfig;
+}
+
+function fedOptions(externals: SharedInfo[]): NormalizedFederationOptions {
+  return {
+    workspaceRoot: '/ws',
+    outputPath: 'dist',
+    dev: true,
+    federationCache: { externals, bundlerCache: {}, cachePath: '/cache' },
+  } as NormalizedFederationOptions;
+}
+
+function repo(): PackageJsonRepository {
+  return {
+    findDepPackageJson: (name: string) =>
+      name === 'a' ? '/ws/node_modules/a/package.json' : null,
+    getPackageJsonFiles: () => [],
+    readJson: () => ({}),
+    exists: () => true,
+  };
+}
+
+// Symlinked (npm-linked) shared package `a` → dev checkout at /dev/a.
+const linkedIo = () =>
+  createMemoryIo().setSymlink('/ws/node_modules/a', '/dev/a').setDir('/cache');
+
+describe('rebuildAffectedExternals — port-injected resolution + invalidation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('re-bundles when a modified file resolves under a symlinked shared package', async () => {
+    const fed = fedOptions([{ packageName: 'a', outFileName: 'a.stale.js' } as SharedInfo]);
+
+    await rebuildAffectedExternals(config(), fed, ['a'], ['/dev/a/src/x.ts'], undefined, linkedIo(), repo());
+
+    expect(executeSharedBundlePlans).toHaveBeenCalledOnce();
+    expect(fed.federationCache.externals).toEqual([{ packageName: 'a', outFileName: 'a.fresh.js' }]);
+  });
+
+  it('reuses cached externals when the modified file is outside every shared dir', async () => {
+    const cached: SharedInfo[] = [{ packageName: 'a', outFileName: 'a.cached.js' } as SharedInfo];
+    const fed = fedOptions(cached);
+
+    await rebuildAffectedExternals(config(), fed, ['a'], ['/unrelated/x.ts'], undefined, linkedIo(), repo());
+
+    expect(executeSharedBundlePlans).not.toHaveBeenCalled();
+    expect(fed.federationCache.externals).toEqual(cached);
+  });
+
+  it('is a no-op when no files changed', async () => {
+    const cached: SharedInfo[] = [{ packageName: 'a', outFileName: 'a.cached.js' } as SharedInfo];
+    const fed = fedOptions(cached);
+
+    await rebuildAffectedExternals(config(), fed, ['a'], [], undefined, linkedIo(), repo());
+
+    expect(executeSharedBundlePlans).not.toHaveBeenCalled();
+    expect(fed.federationCache.externals).toEqual(cached);
+  });
+});

--- a/src/lib/core/build/rebuild-for-federation.spec.ts
+++ b/src/lib/core/build/rebuild-for-federation.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { NormalizedFederationConfig } from '../../domain/config/federation-config.contract.js';
+import type { NormalizedExternalConfig } from '../../domain/config/external-config.contract.js';
+import type { NormalizedFederationOptions } from '../../domain/core/federation-options.contract.js';
+import type { SharedInfo } from '../../domain/core/federation-info.contract.js';
+
+vi.mock('../output/write-federation-info.js', () => ({ writeFederationInfo: vi.fn() }));
+vi.mock('../output/write-import-map.js', () => ({ writeImportMap: vi.fn() }));
+vi.mock('./bundle-exposed-and-mappings.js', () => ({
+  bundleExposedAndMappings: vi.fn(async () => undefined),
+  describeExposed: vi.fn(() => []),
+  describeSharedMappings: vi.fn(() => []),
+}));
+vi.mock('../cache/cache-persistence.js', () => ({
+  cacheEntryCore: vi.fn(() => ({ clear: vi.fn() })),
+  getFilename: vi.fn((name: string) => `${name}.meta.json`),
+}));
+vi.mock('./resolve-shared-dirs.js', () => ({
+  resolveSharedPackageDirs: vi.fn(() => new Map()),
+  affectedSharedKeys: vi.fn(),
+}));
+vi.mock('./build-for-federation.js', () => ({
+  executeSharedBundlePlans: vi.fn(async (_plans, _config, fedOptions) => {
+    fedOptions.federationCache.externals.push({ packageName: 'a', outFileName: 'a.fresh.js' });
+  }),
+}));
+
+const { rebuildForFederation } = await import('./rebuild-for-federation.js');
+const { executeSharedBundlePlans } = await import('./build-for-federation.js');
+const { affectedSharedKeys } = await import('./resolve-shared-dirs.js');
+
+function config(): NormalizedFederationConfig {
+  return {
+    name: 'app',
+    chunks: false,
+    shared: {
+      a: { platform: 'browser', build: 'default', chunks: false } as NormalizedExternalConfig,
+    },
+    features: {},
+  } as unknown as NormalizedFederationConfig;
+}
+
+function fedOptions(externals: SharedInfo[]): NormalizedFederationOptions {
+  return {
+    workspaceRoot: '/ws',
+    outputPath: 'dist',
+    dev: true,
+    federationConfig: 'federation.config.js',
+    projectName: 'app',
+    entryPoints: [],
+    cacheExternalArtifacts: true,
+    federationCache: { externals, bundlerCache: {}, cachePath: '/cache' },
+  } as NormalizedFederationOptions;
+}
+
+describe('rebuildForFederation — affected-external re-bundling', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('re-bundles and replaces externals when a modified file hits a shared package', async () => {
+    vi.mocked(affectedSharedKeys).mockReturnValue(new Set(['a']));
+    const stale: SharedInfo[] = [{ packageName: 'a', outFileName: 'a.stale.js' } as SharedInfo];
+
+    const info = await rebuildForFederation(config(), fedOptions(stale), ['a'], [
+      '/dev/lib/dist/src/a.ts',
+    ]);
+
+    expect(executeSharedBundlePlans).toHaveBeenCalledOnce();
+    expect(info.shared).toEqual([{ packageName: 'a', outFileName: 'a.fresh.js' }]);
+  });
+
+  it('reuses cached externals when no modified file hits a shared package', async () => {
+    vi.mocked(affectedSharedKeys).mockReturnValue(new Set());
+    const cached: SharedInfo[] = [{ packageName: 'a', outFileName: 'a.cached.js' } as SharedInfo];
+
+    const info = await rebuildForFederation(config(), fedOptions(cached), ['a'], [
+      '/unrelated/x.ts',
+    ]);
+
+    expect(executeSharedBundlePlans).not.toHaveBeenCalled();
+    expect(info.shared).toEqual(cached);
+  });
+
+  it('skips detection entirely when no files changed', async () => {
+    const cached: SharedInfo[] = [{ packageName: 'a', outFileName: 'a.cached.js' } as SharedInfo];
+
+    await rebuildForFederation(config(), fedOptions(cached), ['a'], []);
+
+    expect(affectedSharedKeys).not.toHaveBeenCalled();
+    expect(executeSharedBundlePlans).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/core/build/rebuild-for-federation.ts
+++ b/src/lib/core/build/rebuild-for-federation.ts
@@ -10,6 +10,14 @@ import { writeImportMap } from '../output/write-import-map.js';
 import { logger } from '../../utils/logger.js';
 import { AbortedError } from '../../utils/errors.js';
 import type { NormalizedFederationConfig } from '../../domain/config/federation-config.contract.js';
+import { planSharedBundles } from './shared-bundle-plan.js';
+import { executeSharedBundlePlans } from './build-for-federation.js';
+import { affectedSharedKeys, resolveSharedPackageDirs } from './resolve-shared-dirs.js';
+import { cacheEntryCore, getFilename } from '../cache/cache-persistence.js';
+import { nodeIo } from '../../utils/io/node-io-adapter.js';
+import type { IoPort } from '../../domain/utils/io-port.contract.js';
+import type { PackageJsonRepository } from '../../domain/utils/package-json.contract.js';
+import { sharedPackageJsonRepository } from '../../utils/package/package-info.js';
 
 export async function rebuildForFederation(
   config: NormalizedFederationConfig,
@@ -19,6 +27,8 @@ export async function rebuildForFederation(
   signal?: AbortSignal
 ): Promise<FederationInfo> {
   const federationCache = fedOptions.federationCache;
+
+  await rebuildAffectedExternals(config, fedOptions, externals, modifiedFiles, signal);
 
   logger.info(`Re-bundling all internal libraries and exposed modules..'`);
   const start = process.hrtime();
@@ -74,4 +84,44 @@ export async function rebuildForFederation(
   writeImportMap(federationCache, fedOptions, federationInfo.integrity);
 
   return federationInfo;
+}
+
+/**
+ * When a modified file belongs to a shared package (e.g. npm-linked dev dep),
+ * re-bundle the affected bundle(s); unchanged bundles hit their cache, so
+ * `federationCache.externals` regenerates cheaply. No package touched → no-op.
+ */
+export async function rebuildAffectedExternals(
+  config: NormalizedFederationConfig,
+  fedOptions: NormalizedFederationOptions,
+  externals: string[],
+  modifiedFiles: string[],
+  signal?: AbortSignal,
+  io: IoPort = nodeIo,
+  repo: PackageJsonRepository = sharedPackageJsonRepository
+): Promise<void> {
+  if (modifiedFiles.length === 0) return;
+
+  const plans = planSharedBundles(config, externals);
+  if (plans.length === 0) return;
+
+  const dirs = resolveSharedPackageDirs(config, fedOptions, io, repo);
+  const affected = affectedSharedKeys(modifiedFiles, dirs, io);
+  const affectedPlans = plans.filter(p => p.keys.some(k => affected.has(k)));
+  if (affectedPlans.length === 0) return;
+
+  const federationCache = fedOptions.federationCache;
+  // Authoritative, modifiedFiles-driven invalidation. bundleShared already misses
+  // its cache when the content-signal changes, but that signal is an mtime heuristic;
+  // clearing here covers the cases it can miss (mtime granularity, a deleted file).
+  for (const plan of affectedPlans) {
+    logger.info(`Detected change in linked shared package(s); re-bundling '${plan.bundleName}'.`);
+    cacheEntryCore(io, federationCache.cachePath, getFilename(plan.bundleName, fedOptions.dev)).clear();
+  }
+
+  federationCache.externals = [];
+  federationCache.chunks = undefined;
+  federationCache.integrity = undefined;
+
+  await executeSharedBundlePlans(plans, config, fedOptions, signal);
 }

--- a/src/lib/core/build/resolve-shared-dirs.spec.ts
+++ b/src/lib/core/build/resolve-shared-dirs.spec.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import {
+  affectedSharedKeys,
+  linkedContentSignals,
+  linkedSharedDirs,
+  resolveSharedPackageDirs,
+} from './resolve-shared-dirs.js';
+import { createMemoryIo } from '../../utils/io/__test-helpers__/memory-io.js';
+import type { NormalizedFederationConfig } from '../../domain/config/federation-config.contract.js';
+import type { NormalizedFederationOptions } from '../../domain/core/federation-options.contract.js';
+import type { PackageJsonRepository } from '../../domain/utils/package-json.contract.js';
+
+describe('affectedSharedKeys', () => {
+  const dirs = new Map([
+    ['@scope/lib', '/dev/lib/dist'],
+    ['tslib', '/ws/node_modules/tslib'],
+  ]);
+
+  it('flags a package when a modified file lives under its directory', () => {
+    const io = createMemoryIo();
+    const affected = affectedSharedKeys(['/dev/lib/dist/src/a.js'], dirs, io);
+    expect([...affected]).toEqual(['@scope/lib']);
+  });
+
+  it('resolves symlinked modified paths before matching', () => {
+    const io = createMemoryIo().setSymlink('/ws/node_modules/@scope/lib', '/dev/lib/dist');
+    const affected = affectedSharedKeys(['/ws/node_modules/@scope/lib/src/a.js'], dirs, io);
+    expect([...affected]).toEqual(['@scope/lib']);
+  });
+
+  it('returns empty when no modified file matches a shared dir', () => {
+    const io = createMemoryIo();
+    expect(affectedSharedKeys(['/somewhere/else/a.js'], dirs, io).size).toBe(0);
+    expect(affectedSharedKeys([], dirs, io).size).toBe(0);
+  });
+
+  it('does not match a sibling dir sharing a name prefix', () => {
+    const io = createMemoryIo();
+    const affected = affectedSharedKeys(['/dev/lib-extra/src/a.js'], dirs, io);
+    expect(affected.size).toBe(0);
+  });
+});
+
+describe('resolveSharedPackageDirs', () => {
+  function repoReturning(map: Record<string, string | null>): PackageJsonRepository {
+    return {
+      findDepPackageJson: (name: string) => map[name] ?? null,
+      getPackageJsonFiles: () => [],
+      readJson: () => ({}),
+      exists: () => true,
+    };
+  }
+
+  const config = { shared: { '@scope/lib': {}, missing: {} } } as unknown as NormalizedFederationConfig;
+  const fedOptions = { workspaceRoot: '/ws' } as NormalizedFederationOptions;
+
+  it('maps each key to its realpath, following symlinks', () => {
+    const io = createMemoryIo().setSymlink('/ws/node_modules/@scope/lib', '/dev/lib');
+    const repo = repoReturning({ '@scope/lib': '/ws/node_modules/@scope/lib/package.json' });
+
+    const dirs = resolveSharedPackageDirs(config, fedOptions, io, repo);
+    expect(dirs.get('@scope/lib')).toBe('/dev/lib');
+  });
+
+  it('skips keys whose package.json cannot be resolved', () => {
+    const io = createMemoryIo();
+    const repo = repoReturning({ '@scope/lib': '/ws/node_modules/@scope/lib/package.json' });
+
+    const dirs = resolveSharedPackageDirs(config, fedOptions, io, repo);
+    expect(dirs.has('missing')).toBe(false);
+  });
+});
+
+describe('linkedSharedDirs', () => {
+  function repoReturning(map: Record<string, string | null>): PackageJsonRepository {
+    return {
+      findDepPackageJson: (name: string) => map[name] ?? null,
+      getPackageJsonFiles: () => [],
+      readJson: () => ({}),
+      exists: () => true,
+    };
+  }
+
+  it('returns realpath dirs of symlinked packages only, deduped', () => {
+    const cfg = {
+      shared: { '@scope/lib': {}, '@scope/lib/sub': {}, tslib: {} },
+    } as unknown as NormalizedFederationConfig;
+    const fedOptions = { workspaceRoot: '/ws' } as NormalizedFederationOptions;
+
+    const io = createMemoryIo()
+      .setSymlink('/ws/node_modules/@scope/lib', '/dev/lib')
+      .setSymlink('/ws/node_modules/@scope/lib/sub', '/dev/lib');
+    const repo = repoReturning({
+      '@scope/lib': '/ws/node_modules/@scope/lib/package.json',
+      // secondary resolves to the same main package dir (symlinked)
+      '@scope/lib/sub': '/ws/node_modules/@scope/lib/package.json',
+      tslib: '/ws/node_modules/tslib/package.json',
+    });
+
+    expect(linkedSharedDirs(cfg, fedOptions, io, repo)).toEqual(['/dev/lib']);
+  });
+});
+
+describe('linkedContentSignals', () => {
+  function repoReturning(map: Record<string, string | null>): PackageJsonRepository {
+    return {
+      findDepPackageJson: (name: string) => map[name] ?? null,
+      getPackageJsonFiles: () => [],
+      readJson: () => ({}),
+      exists: () => true,
+    };
+  }
+
+  const repo = repoReturning({
+    '@scope/lib': '/ws/node_modules/@scope/lib/package.json',
+    tslib: '/ws/node_modules/tslib/package.json',
+  });
+
+  it('emits a max-mtime signal for symlinked packages only', () => {
+    const io = createMemoryIo()
+      .setSymlink('/ws/node_modules/@scope/lib', '/dev/lib')
+      .setFile('/dev/lib/a.js', 'A')
+      .setMtime('/dev/lib/a.js', 100)
+      .setFile('/dev/lib/nested/b.js', 'B')
+      .setMtime('/dev/lib/nested/b.js', 300)
+      // tslib is a real (non-symlink) dir → no signal.
+      .setFile('/ws/node_modules/tslib/index.js', 'T');
+
+    const signals = linkedContentSignals(['@scope/lib', 'tslib'], '/ws', io, repo);
+
+    expect(signals['@scope/lib']).toBe('300');
+    expect(signals).not.toHaveProperty('tslib');
+  });
+
+  it('tracks the newest mtime so an edit changes the signal', () => {
+    const build = (mtime: number) =>
+      linkedContentSignals(
+        ['@scope/lib'],
+        '/ws',
+        createMemoryIo()
+          .setSymlink('/ws/node_modules/@scope/lib', '/dev/lib')
+          .setFile('/dev/lib/a.js', 'A')
+          .setMtime('/dev/lib/a.js', mtime),
+        repo
+      )['@scope/lib'];
+
+    expect(build(100)).toBe('100');
+    expect(build(100)).toBe('100');
+    expect(build(200)).not.toBe('100');
+  });
+
+  it('follows a symlinked file to its target mtime, not the link mtime', () => {
+    const io = createMemoryIo()
+      .setSymlink('/ws/node_modules/@scope/lib', '/dev/lib')
+      .setFile('/dev/lib/a.js', 'A')
+      .setMtime('/dev/lib/a.js', 100)
+      // b.js is itself a symlink; its target is newer than any lstat mtime in the dir.
+      .setFile('/dev/lib/b.js', 'B')
+      .setSymlink('/dev/lib/b.js', '/other/b-real.js')
+      .setMtime('/dev/lib/b.js', 200)
+      .setFile('/other/b-real.js', 'BR')
+      .setMtime('/other/b-real.js', 500);
+
+    const signals = linkedContentSignals(['@scope/lib'], '/ws', io, repo);
+
+    expect(signals['@scope/lib']).toBe('500');
+  });
+});

--- a/src/lib/core/build/resolve-shared-dirs.ts
+++ b/src/lib/core/build/resolve-shared-dirs.ts
@@ -1,0 +1,115 @@
+import * as path from 'path';
+import type { NormalizedFederationConfig } from '../../domain/config/federation-config.contract.js';
+import type { NormalizedFederationOptions } from '../../domain/core/federation-options.contract.js';
+import type { FileReaderPort } from '../../domain/utils/io-port.contract.js';
+import type { PackageJsonRepository } from '../../domain/utils/package-json.contract.js';
+import { nodeIo } from '../../utils/io/node-io-adapter.js';
+import { sharedPackageJsonRepository } from '../../utils/package/package-info.js';
+import { toPosix } from '../../utils/path-patterns.js';
+
+interface SharedEntry {
+  key: string;
+  /** realpath'd package directory (symlink resolved to its dev checkout). */
+  realDir: string;
+  isSymlink: boolean;
+}
+
+const folderOf = (fedOptions: NormalizedFederationOptions): string =>
+  fedOptions.packageJson ? path.dirname(fedOptions.packageJson) : fedOptions.workspaceRoot;
+
+function resolveEntries(
+  keys: readonly string[],
+  folder: string,
+  io: FileReaderPort,
+  repo: PackageJsonRepository
+): SharedEntry[] {
+  const out: SharedEntry[] = [];
+  for (const key of keys) {
+    const pkgJsonPath = repo.findDepPackageJson(key, folder);
+    if (!pkgJsonPath) continue;
+    const pkgDir = path.dirname(pkgJsonPath);
+    out.push({
+      key,
+      realDir: toPosix(io.realpath(pkgDir)),
+      isSymlink: !!io.stat(pkgDir)?.isSymbolicLink,
+    });
+  }
+  return out;
+}
+
+/** Each `config.shared` key → its realpath'd package dir, so watcher, checksum, and
+ *  file-mapping agree on one identity for symlinked (npm-linked) deps. */
+export function resolveSharedPackageDirs(
+  config: NormalizedFederationConfig,
+  fedOptions: NormalizedFederationOptions,
+  io: FileReaderPort = nodeIo,
+  repo: PackageJsonRepository = sharedPackageJsonRepository
+): Map<string, string> {
+  const entries = resolveEntries(Object.keys(config.shared), folderOf(fedOptions), io, repo);
+  return new Map(entries.map(e => [e.key, e.realDir]));
+}
+
+/** Realpath'd dirs of symlinked shared packages — the bounded watch set.
+ *  Deduped, since secondaries share a package dir. */
+export function linkedSharedDirs(
+  config: NormalizedFederationConfig,
+  fedOptions: NormalizedFederationOptions,
+  io: FileReaderPort = nodeIo,
+  repo: PackageJsonRepository = sharedPackageJsonRepository
+): string[] {
+  const entries = resolveEntries(Object.keys(config.shared), folderOf(fedOptions), io, repo);
+  return [...new Set(entries.filter(e => e.isSymlink).map(e => e.realDir))];
+}
+
+function maxMtime(io: FileReaderPort, dir: string): number {
+  let max = 0;
+  const walk = (d: string) => {
+    for (const name of io.readDir(d)) {
+      const full = path.join(d, name);
+      if (io.isDirectory(full)) walk(full);
+      else {
+        let s = io.stat(full);
+        // stat is lstat-based: a symlinked file reports the link's own mtime, not the
+        // target's. Follow it so an edit to the real file still moves the signal.
+        if (s?.isSymbolicLink) s = io.stat(io.realpath(full));
+        if (s && s.mtimeMs > max) max = s.mtimeMs;
+      }
+    }
+  };
+  walk(dir);
+  return max;
+}
+
+/** Per-key content signal (max mtime of the resolved dir) for symlinked deps only.
+ *  Registry deps get no signal, keeping their checksum version-only. (Every key is
+ *  still resolved: detecting the symlink requires the realpath + lstat.) */
+export function linkedContentSignals(
+  keys: string[],
+  folder: string,
+  io: FileReaderPort = nodeIo,
+  repo: PackageJsonRepository = sharedPackageJsonRepository
+): Record<string, string> {
+  const signals: Record<string, string> = {};
+  for (const entry of resolveEntries(keys, folder, io, repo)) {
+    if (entry.isSymlink) signals[entry.key] = String(maxMtime(io, entry.realDir));
+  }
+  return signals;
+}
+
+/** `config.shared` keys whose package directory contains at least one modified file. */
+export function affectedSharedKeys(
+  modifiedFiles: readonly string[],
+  dirs: Map<string, string>,
+  io: FileReaderPort = nodeIo
+): Set<string> {
+  const affected = new Set<string>();
+  if (modifiedFiles.length === 0 || dirs.size === 0) return affected;
+
+  const realFiles = modifiedFiles.map(f => toPosix(io.realpath(f)));
+
+  for (const [key, dir] of dirs) {
+    const prefix = dir.endsWith('/') ? dir : dir + '/';
+    if (realFiles.some(f => f === dir || f.startsWith(prefix))) affected.add(key);
+  }
+  return affected;
+}

--- a/src/lib/core/build/shared-bundle-plan.spec.ts
+++ b/src/lib/core/build/shared-bundle-plan.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { planSharedBundles, splitShared } from './shared-bundle-plan.js';
+import type { NormalizedFederationConfig } from '../../domain/config/federation-config.contract.js';
+import type { NormalizedExternalConfig } from '../../domain/config/external-config.contract.js';
+
+function ext(overrides: Partial<NormalizedExternalConfig> = {}): NormalizedExternalConfig {
+  return {
+    singleton: true,
+    strictVersion: true,
+    requiredVersion: '^1.0.0',
+    platform: 'browser',
+    build: 'default',
+    chunks: false,
+    ...overrides,
+  } as NormalizedExternalConfig;
+}
+
+function config(shared: Record<string, NormalizedExternalConfig>): NormalizedFederationConfig {
+  return { chunks: false, shared } as NormalizedFederationConfig;
+}
+
+describe('planSharedBundles', () => {
+  it('groups default packages into one browser-shared and one node-shared bundle', () => {
+    const plans = planSharedBundles(
+      config({
+        a: ext({ platform: 'browser' }),
+        b: ext({ platform: 'browser' }),
+        c: ext({ platform: 'node' }),
+      }),
+      ['a', 'b', 'c']
+    );
+
+    const browser = plans.find(p => p.bundleName === 'browser-shared');
+    const node = plans.find(p => p.bundleName === 'node-shared');
+    expect(browser?.keys).toEqual(['a', 'b']);
+    expect(node?.keys).toEqual(['c']);
+    expect(plans.every(p => p.kind === 'shared')).toBe(true);
+  });
+
+  it('gives each separate package its own bundle and trims its own externals', () => {
+    const plans = planSharedBundles(
+      config({
+        '@scope/lib': ext({ platform: 'browser', build: 'separate' }),
+      }),
+      ['@scope/lib', 'other']
+    );
+
+    expect(plans).toHaveLength(1);
+    expect(plans[0]!.bundleName).toBe('browser-scope_lib');
+    expect(plans[0]!.kind).toBe('separate');
+    expect(plans[0]!.externals).toEqual(['other']);
+  });
+
+  it('splitShared routes by platform and build type', () => {
+    const { sharedBrowser, sharedServer, separateBrowser, separateServer } = splitShared({
+      a: ext({ platform: 'browser', build: 'default' }),
+      b: ext({ platform: 'node', build: 'default' }),
+      c: ext({ platform: 'browser', build: 'separate' }),
+      d: ext({ platform: 'node', build: 'separate' }),
+    });
+    expect(Object.keys(sharedBrowser)).toEqual(['a']);
+    expect(Object.keys(sharedServer)).toEqual(['b']);
+    expect(Object.keys(separateBrowser)).toEqual(['c']);
+    expect(Object.keys(separateServer)).toEqual(['d']);
+  });
+});

--- a/src/lib/core/build/shared-bundle-plan.ts
+++ b/src/lib/core/build/shared-bundle-plan.ts
@@ -1,0 +1,110 @@
+import type { NormalizedFederationConfig } from '../../domain/config/federation-config.contract.js';
+import type { NormalizedExternalConfig } from '../../domain/config/external-config.contract.js';
+import { inferPackageFromSecondary, normalizePackageName } from '../../utils/normalize.js';
+
+export interface SharedBundlePlan {
+  bundleName: string;
+  platform: 'browser' | 'node';
+  chunks: boolean;
+  entries: Record<string, NormalizedExternalConfig>;
+  externals: string[];
+  keys: string[];
+  kind: 'shared' | 'separate';
+}
+
+type SplitSharedResult = {
+  sharedServer: Record<string, NormalizedExternalConfig>;
+  sharedBrowser: Record<string, NormalizedExternalConfig>;
+  separateBrowser: Record<string, NormalizedExternalConfig>;
+  separateServer: Record<string, NormalizedExternalConfig>;
+};
+
+export function splitShared(
+  shared: Record<string, NormalizedExternalConfig>
+): SplitSharedResult {
+  const sharedServer: Record<string, NormalizedExternalConfig> = {};
+  const sharedBrowser: Record<string, NormalizedExternalConfig> = {};
+  const separateBrowser: Record<string, NormalizedExternalConfig> = {};
+  const separateServer: Record<string, NormalizedExternalConfig> = {};
+
+  for (const key in shared) {
+    const obj = shared[key];
+    if (obj?.platform === 'node') {
+      if (obj.build === 'default') sharedServer[key] = obj;
+      else separateServer[key] = obj;
+    } else if (obj?.platform === 'browser') {
+      if (obj.build === 'default') sharedBrowser[key] = obj;
+      else separateBrowser[key] = obj;
+    }
+  }
+
+  return { sharedBrowser, sharedServer, separateBrowser, separateServer };
+}
+
+function planSeparate(
+  separate: Record<string, NormalizedExternalConfig>,
+  platform: 'browser' | 'node',
+  externals: string[]
+): SharedBundlePlan[] {
+  const grouped: Record<
+    string,
+    { entries: Record<string, NormalizedExternalConfig>; chunks: boolean }
+  > = {};
+
+  for (const [key, shared] of Object.entries(separate)) {
+    const packageName = shared.build === 'separate' ? key : inferPackageFromSecondary(key);
+    if (!grouped[packageName]) grouped[packageName] = { chunks: shared.chunks, entries: {} };
+    grouped[packageName].entries[key] = shared;
+  }
+
+  return Object.entries(grouped).map(([packageName, group]) => ({
+    bundleName: `${platform}-${normalizePackageName(packageName)}`,
+    platform,
+    chunks: group.chunks,
+    entries: group.entries,
+    externals: externals.filter(e => !e.startsWith(packageName)),
+    keys: Object.keys(group.entries),
+    kind: 'separate',
+  }));
+}
+
+/** Single source of truth for package → bundle(name) mapping, shared by the initial
+ *  build and the watch rebuild so both target the same cache entries. */
+export function planSharedBundles(
+  config: NormalizedFederationConfig,
+  externals: string[]
+): SharedBundlePlan[] {
+  const { sharedBrowser, sharedServer, separateBrowser, separateServer } = splitShared(
+    config.shared
+  );
+
+  const plans: SharedBundlePlan[] = [];
+
+  if (Object.keys(sharedBrowser).length > 0) {
+    plans.push({
+      bundleName: 'browser-shared',
+      platform: 'browser',
+      chunks: config.chunks,
+      entries: sharedBrowser,
+      externals,
+      keys: Object.keys(sharedBrowser),
+      kind: 'shared',
+    });
+  }
+  if (Object.keys(sharedServer).length > 0) {
+    plans.push({
+      bundleName: 'node-shared',
+      platform: 'node',
+      chunks: config.chunks,
+      entries: sharedServer,
+      externals,
+      keys: Object.keys(sharedServer),
+      kind: 'shared',
+    });
+  }
+
+  plans.push(...planSeparate(separateBrowser, 'browser', externals));
+  plans.push(...planSeparate(separateServer, 'node', externals));
+
+  return plans;
+}

--- a/src/lib/core/cache/cache-persistence.spec.ts
+++ b/src/lib/core/cache/cache-persistence.spec.ts
@@ -70,6 +70,30 @@ describe('getChecksumCore', () => {
       .digest('hex');
     expect(getChecksumCore(io, { react: ext('18') }, '0', '2.0.0')).toBe(expected);
   });
+
+  // Registry-dep regression guard: an empty content-signal map must not perturb the hash.
+  it('is byte-identical whether contentSignals is omitted or empty', () => {
+    const base = { react: ext('18') };
+    expect(getChecksumCore(io, base, '0', '2.0.0', true, {})).toBe(
+      getChecksumCore(io, base, '0', '2.0.0')
+    );
+  });
+
+  it('changes when a content signal is added for a (linked) package', () => {
+    const base = { '@scope/lib': ext('1.0.0') };
+    expect(getChecksumCore(io, base, '0', '', true, { '@scope/lib': '111' })).not.toBe(
+      getChecksumCore(io, base, '0')
+    );
+  });
+
+  it('changes when a content signal changes but is stable when it does not', () => {
+    const base = { '@scope/lib': ext('1.0.0') };
+    const a = getChecksumCore(io, base, '0', '', true, { '@scope/lib': '111' });
+    const b = getChecksumCore(io, base, '0', '', true, { '@scope/lib': '222' });
+    const aAgain = getChecksumCore(io, base, '0', '', true, { '@scope/lib': '111' });
+    expect(a).not.toBe(b);
+    expect(a).toBe(aAgain);
+  });
 });
 
 describe('cacheEntryCore', () => {

--- a/src/lib/core/cache/cache-persistence.ts
+++ b/src/lib/core/cache/cache-persistence.ts
@@ -25,22 +25,26 @@ export const getChecksum = (
   shared: Record<string, NormalizedExternalConfig>,
   dev: '1' | '0',
   builderVersion = '',
-  synthesizeCjsExports = true
-): string => getChecksumCore(nodeIo, shared, dev, builderVersion, synthesizeCjsExports);
+  synthesizeCjsExports = true,
+  contentSignals: Record<string, string> = {}
+): string =>
+  getChecksumCore(nodeIo, shared, dev, builderVersion, synthesizeCjsExports, contentSignals);
 
 export const getChecksumCore = (
   hash: HashPort,
   shared: Record<string, NormalizedExternalConfig>,
   dev: '1' | '0',
   builderVersion = '',
-  synthesizeCjsExports = true
+  synthesizeCjsExports = true,
+  // Per-key content signal, set only for symlinked deps; empty map => version-only hash.
+  contentSignals: Record<string, string> = {}
 ): string => {
   const denseExternals = Object.keys(shared)
     .sort()
     .reduce((clean, external) => {
-      return (
-        clean + ':' + external + (shared[external]!.version ? `@${shared[external]!.version}` : '')
-      );
+      const version = shared[external]!.version ? `@${shared[external]!.version}` : '';
+      const signal = contentSignals[external] ? `#${contentSignals[external]}` : '';
+      return clean + ':' + external + version + signal;
     }, 'deps');
 
   const cjs = synthesizeCjsExports ? '1' : '0';

--- a/src/lib/core/federation-builder.ts
+++ b/src/lib/core/federation-builder.ts
@@ -67,4 +67,7 @@ export const federationBuilder = {
   get config(): NormalizedFederationConfig {
     return config;
   },
+  get options(): NormalizedFederationOptions {
+    return options;
+  },
 };

--- a/src/lib/domain/utils/file-watcher.contract.ts
+++ b/src/lib/domain/utils/file-watcher.contract.ts
@@ -1,9 +1,15 @@
 export interface NfFileWatcherOptions {
   onChange?: (path: string) => void;
+  pollIntervalMs?: number;
+  debounceMs?: number;
+}
+
+interface AddPathsOptions {
+  poll?: boolean;
 }
 
 export interface NfFileWatcher {
-  addPaths(paths: string | readonly string[]): void;
+  addPaths(paths: string | readonly string[], opts?: AddPathsOptions): void;
   close(): Promise<void>;
   get(): ReadonlySet<string>;
   clear(): void;

--- a/src/lib/domain/utils/io-port.contract.ts
+++ b/src/lib/domain/utils/io-port.contract.ts
@@ -5,6 +5,11 @@ export interface Digest {
   base64(): string;
 }
 
+export interface StatInfo {
+  mtimeMs: number;
+  isSymbolicLink: boolean;
+}
+
 export interface FileReaderPort {
   readText(path: string): string;
   readBytes(path: string): Uint8Array;
@@ -15,6 +20,8 @@ export interface FileReaderPort {
   isDirectory(path: string): boolean;
   /** Immediate child entry names (not full paths). Empty array on ENOENT, never throws. */
   readDir(path: string): string[];
+  realpath(path: string): string;
+  stat(path: string): StatInfo | null;
 }
 
 export interface FileWriterPort {
@@ -36,6 +43,11 @@ export interface WatchHandle {
   close(): void;
 }
 
+interface WatchOptions {
+  recursive: boolean;
+  poll?: { intervalMs: number };
+}
+
 export interface WatchPort {
   /**
    * For a recursive directory watch `onEvent` receives the changed entry's
@@ -44,7 +56,7 @@ export interface WatchPort {
    */
   watch(
     path: string,
-    opts: { recursive: boolean },
+    opts: WatchOptions,
     onEvent: (filename: string | null) => void
   ): WatchHandle;
 }

--- a/src/lib/utils/file-watcher.spec.ts
+++ b/src/lib/utils/file-watcher.spec.ts
@@ -50,6 +50,43 @@ describe('createNfWatcherCore', () => {
     expect(debug).toHaveBeenCalled();
   });
 
+  it('passes the poll option to io.watch for polled paths', () => {
+    const dir = path.resolve('/proj/src');
+    const io = createMemoryIo().setDir(dir);
+    const spy = vi.spyOn(io, 'watch');
+    const watcher = createNfWatcherCore(io, { pollIntervalMs: 250 });
+
+    watcher.addPaths(dir, { poll: true });
+
+    expect(spy).toHaveBeenCalledWith(
+      dir,
+      expect.objectContaining({ recursive: true, poll: { intervalMs: 250 } }),
+      expect.any(Function)
+    );
+  });
+
+  it('coalesces a burst of events into one delivery per path when debounced', () => {
+    vi.useFakeTimers();
+    const dir = path.resolve('/proj/src').replace(/\\/g, '/');
+    const io = createMemoryIo().setDir(dir);
+    const onChange = vi.fn();
+    const watcher = createNfWatcherCore(io, { onChange, debounceMs: 50 });
+
+    watcher.addPaths(dir);
+    io.emit(dir, 'a.ts');
+    io.emit(dir, 'a.ts');
+    io.emit(dir, 'b.ts');
+
+    expect(onChange).not.toHaveBeenCalled(); // nothing before the quiet window elapses
+
+    vi.advanceTimersByTime(50);
+
+    expect(onChange).toHaveBeenCalledTimes(2); // a.ts + b.ts, deduped
+    expect(onChange).toHaveBeenCalledWith(`${dir}/a.ts`);
+    expect(onChange).toHaveBeenCalledWith(`${dir}/b.ts`);
+    vi.useRealTimers();
+  });
+
   it('clear() empties the dirty set and close() stops watchers', async () => {
     const dir = path.resolve('/proj/src');
     const io = createMemoryIo().setDir(dir);
@@ -81,5 +118,21 @@ describe('syncNfFileWatcher', () => {
     });
 
     expect(added).toEqual(['/proj/a.ts']);
+  });
+
+  it('adds linked shared dirs alongside the filtered cache keys', () => {
+    const added: string[] = [];
+    const watcher = {
+      addPaths: (p: string | readonly string[]) =>
+        added.push(...(typeof p === 'string' ? [p] : [...p])),
+    } as never;
+
+    syncNfFileWatcher(
+      watcher,
+      { keys: () => ['/proj/a.ts', '/proj/node_modules/x/index.js'][Symbol.iterator]() },
+      ['/dev/lib/dist']
+    );
+
+    expect(added).toEqual(['/proj/a.ts', '/dev/lib/dist']);
   });
 });

--- a/src/lib/utils/file-watcher.ts
+++ b/src/lib/utils/file-watcher.ts
@@ -14,26 +14,43 @@ export function createNfWatcherCore(
   options: NfFileWatcherOptions = {}
 ): NfFileWatcher {
   const { onChange } = options;
+  const pollIntervalMs = options.pollIntervalMs ?? 300;
+  const debounceMs = options.debounceMs ?? 0;
   const watchers = new Map<string, WatchHandle>();
   const dirtyPaths = new Set<string>();
 
-  const notify = (path: string) => {
+  const deliver = (path: string) => {
     if (onChange) onChange(path);
     else dirtyPaths.add(path);
   };
 
+  // Coalesce bursts (ng-packagr emits several writes per rebuild) into one flush.
+  const pending = new Set<string>();
+  let flushTimer: ReturnType<typeof setTimeout> | undefined;
+  const flush = () => {
+    for (const p of pending) deliver(p);
+    pending.clear();
+  };
+  const notify = (path: string) => {
+    if (debounceMs <= 0) return deliver(path);
+    pending.add(path);
+    if (flushTimer) clearTimeout(flushTimer);
+    flushTimer = setTimeout(flush, debounceMs);
+    flushTimer.unref?.();
+  };
+
   return {
-    addPaths(paths) {
+    addPaths(paths, opts) {
       const list = typeof paths === 'string' ? [paths] : [...paths];
+      const poll = opts?.poll ? { intervalMs: pollIntervalMs } : undefined;
       for (const p of list) {
         if (watchers.has(p)) continue;
         try {
-          const isDir = io.isDirectory(p);
-          const handle = isDir
-            ? io.watch(p, { recursive: true }, filename => {
+          const handle = io.isDirectory(p)
+            ? io.watch(p, { recursive: true, poll }, filename => {
                 if (filename) notify(toPosix(join(p, filename)));
               })
-            : io.watch(p, { recursive: false }, () => notify(toPosix(p)));
+            : io.watch(p, { recursive: false, poll }, () => notify(toPosix(p)));
           watchers.set(p, handle);
         } catch {
           logger.debug(`Could not watch path '${p}'.`);
@@ -46,6 +63,7 @@ export function createNfWatcherCore(
     mutate: fn => fn(dirtyPaths),
 
     async close() {
+      if (flushTimer) clearTimeout(flushTimer);
       for (const handle of watchers.values()) {
         handle.close();
       }
@@ -56,8 +74,12 @@ export function createNfWatcherCore(
 
 export function syncNfFileWatcher(
   watcher: NfFileWatcher,
-  bundlerCache: { keys(): IterableIterator<string> }
+  bundlerCache: { keys(): IterableIterator<string> },
+  // Realpath'd dirs of symlinked (npm-linked) shared packages — watched despite
+  // living under node_modules. See core's `linkedSharedDirs`.
+  linkedDirs: readonly string[] = []
 ): void {
   const files = [...bundlerCache.keys()].filter(k => !k.includes('node_modules'));
   if (files.length) watcher.addPaths(files);
+  if (linkedDirs.length) watcher.addPaths(linkedDirs, { poll: true });
 }

--- a/src/lib/utils/io/__test-helpers__/memory-io.ts
+++ b/src/lib/utils/io/__test-helpers__/memory-io.ts
@@ -4,6 +4,7 @@ import type {
   Digest,
   HashAlgorithm,
   IoPort,
+  StatInfo,
   WatchHandle,
 } from '../../../domain/utils/io-port.contract.js';
 
@@ -12,6 +13,10 @@ import type {
 export interface MemoryIo extends IoPort {
   setFile(filePath: string, data: string | Uint8Array): MemoryIo;
   setDir(dirPath: string): MemoryIo;
+  /** Register `linkPath` as a symlink resolving to `target` (for realpath/stat). */
+  setSymlink(linkPath: string, target: string): MemoryIo;
+  /** Set an entry's mtime (ms) reported by `stat`. */
+  setMtime(filePath: string, mtimeMs: number): MemoryIo;
   files(): string[];
   emit(watchedPath: string, filename?: string | null): void;
 }
@@ -26,6 +31,8 @@ export function createMemoryIo(): MemoryIo {
   const files = new Map<string, Uint8Array>();
   const dirs = new Set<string>();
   const watchers = new Map<string, Array<(filename: string | null) => void>>();
+  const symlinks = new Map<string, string>();
+  const mtimes = new Map<string, number>();
 
   const encode = (data: string | Uint8Array): Uint8Array =>
     typeof data === 'string' ? new TextEncoder().encode(data) : data;
@@ -58,6 +65,14 @@ export function createMemoryIo(): MemoryIo {
     },
     setDir(dirPath) {
       dirs.add(toKey(dirPath));
+      return io;
+    },
+    setSymlink(linkPath, target) {
+      symlinks.set(toKey(linkPath), toKey(target));
+      return io;
+    },
+    setMtime(filePath, mtimeMs) {
+      mtimes.set(toKey(filePath), mtimeMs);
       return io;
     },
     files() {
@@ -95,6 +110,20 @@ export function createMemoryIo(): MemoryIo {
         if (path.posix.dirname(entry) === key) names.add(path.posix.basename(entry));
       }
       return [...names];
+    },
+    realpath(p) {
+      const key = toKey(p);
+      for (const [link, target] of symlinks) {
+        if (key === link) return target;
+        if (key.startsWith(link + '/')) return target + key.slice(link.length);
+      }
+      return key;
+    },
+    stat(p): StatInfo | null {
+      const key = toKey(p);
+      const isSymbolicLink = symlinks.has(key);
+      if (!isSymbolicLink && !files.has(key) && !dirs.has(key)) return null;
+      return { mtimeMs: mtimes.get(key) ?? 0, isSymbolicLink };
     },
     writeText(p, data) {
       const key = toKey(p);

--- a/src/lib/utils/io/node-io-adapter.spec.ts
+++ b/src/lib/utils/io/node-io-adapter.spec.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { nodeIo } from './node-io-adapter.js';
+
+describe('nodeIo', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'nf-io-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  describe('realpath', () => {
+    it('resolves a symlink to its target', () => {
+      const target = path.join(root, 'target');
+      const link = path.join(root, 'link');
+      fs.mkdirSync(target);
+      fs.symlinkSync(target, link, 'dir');
+
+      expect(nodeIo.realpath(link)).toBe(fs.realpathSync(target));
+    });
+
+    it('returns the input unchanged when the path does not exist', () => {
+      const missing = path.join(root, 'nope');
+      expect(nodeIo.realpath(missing)).toBe(missing);
+    });
+  });
+
+  describe('stat', () => {
+    it('flags a symlink without following it', () => {
+      const target = path.join(root, 'target');
+      const link = path.join(root, 'link');
+      fs.mkdirSync(target);
+      fs.symlinkSync(target, link, 'dir');
+
+      expect(nodeIo.stat(link)?.isSymbolicLink).toBe(true);
+      expect(nodeIo.stat(target)?.isSymbolicLink).toBe(false);
+    });
+
+    it('returns null on ENOENT', () => {
+      expect(nodeIo.stat(path.join(root, 'nope'))).toBeNull();
+    });
+  });
+
+  describe('watch (poll)', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('detects an atomic rewrite that changes the inode', () => {
+      const file = path.join(root, 'a.js');
+      fs.writeFileSync(file, 'v1');
+
+      const seen: (string | null)[] = [];
+      const handle = nodeIo.watch(root, { recursive: true, poll: { intervalMs: 100 } }, f =>
+        seen.push(f)
+      );
+
+      // Atomic replace: write a temp file and rename over the original (new inode).
+      const tmp = path.join(root, 'a.js.tmp');
+      fs.writeFileSync(tmp, 'v2');
+      fs.renameSync(tmp, file);
+
+      vi.advanceTimersByTime(100);
+      handle.close();
+
+      expect(seen).toContain('a.js');
+    });
+  });
+});

--- a/src/lib/utils/io/node-io-adapter.ts
+++ b/src/lib/utils/io/node-io-adapter.ts
@@ -1,10 +1,12 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import * as crypto from 'crypto';
 import fg from 'fast-glob';
 import type {
   Digest,
   HashAlgorithm,
   IoPort,
+  StatInfo,
   WatchHandle,
 } from '../../domain/utils/io-port.contract.js';
 
@@ -39,6 +41,21 @@ export const nodeIo: IoPort = {
       return [];
     }
   },
+  realpath(path) {
+    try {
+      return fs.realpathSync(path);
+    } catch {
+      return path;
+    }
+  },
+  stat(path): StatInfo | null {
+    try {
+      const s = fs.lstatSync(path);
+      return { mtimeMs: s.mtimeMs, isSymbolicLink: s.isSymbolicLink() };
+    } catch {
+      return null;
+    }
+  },
   writeText(path, data) {
     fs.writeFileSync(path, data, 'utf-8');
   },
@@ -61,12 +78,62 @@ export const nodeIo: IoPort = {
       base64: () => sum.digest('base64'),
     };
   },
-  watch(path, opts, onEvent): WatchHandle {
+  watch(watchPath, opts, onEvent): WatchHandle {
+    if (opts.poll) return pollWatch(watchPath, opts.recursive, opts.poll.intervalMs, onEvent);
     const watcher = opts.recursive
-      ? fs.watch(path, { recursive: true }, (_event, filename) =>
+      ? fs.watch(watchPath, { recursive: true }, (_event, filename) =>
           onEvent(filename ? filename.toString() : null)
         )
-      : fs.watch(path, () => onEvent(path));
+      : fs.watch(watchPath, () => onEvent(watchPath));
     return { close: () => watcher.close() };
   },
 };
+
+// mtime-scan fallback: ng-packagr's atomic dist rewrites change the inode and
+// defeat native fs.watch. Emits changed/added/removed entries relative to `root`.
+function pollWatch(
+  root: string,
+  recursive: boolean,
+  intervalMs: number,
+  onEvent: (filename: string | null) => void
+): WatchHandle {
+  const snapshot = (): Map<string, number> => {
+    const out = new Map<string, number>();
+    const walk = (dir: string) => {
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (recursive) walk(full);
+        } else {
+          try {
+            out.set(path.relative(root, full), fs.statSync(full).mtimeMs);
+          } catch {
+            /* vanished between readdir and stat */
+          }
+        }
+      }
+    };
+    walk(root);
+    return out;
+  };
+
+  let prev = snapshot();
+  const timer = setInterval(() => {
+    const next = snapshot();
+    for (const [rel, mtime] of next) {
+      if (prev.get(rel) !== mtime) onEvent(rel);
+    }
+    for (const rel of prev.keys()) {
+      if (!next.has(rel)) onEvent(rel);
+    }
+    prev = next;
+  }, intervalMs);
+  timer.unref?.();
+  return { close: () => clearInterval(timer) };
+}


### PR DESCRIPTION
Fixes https://github.com/native-federation/angular-adapter/issues/55

This pull request refactors and improves the handling of shared and external package bundling in the federation build system. It introduces a new, unified planning and execution system for bundling shared and separate externals, ensures that linked shared directories and content changes are properly tracked for cache invalidation, and adds comprehensive tests for the rebuild logic. The changes streamline the codebase, improve cache correctness, and make the system more robust to changes in linked packages.

**Bundling and Planning Refactor:**
- Replaces the previous ad-hoc logic for splitting and bundling shared/separate externals with a unified planning approach using `planSharedBundles` and `executeSharedBundlePlans`, simplifying the flow and making it easier to maintain and extend. (`src/lib/core/build/build-for-federation.ts` [[1]](diffhunk://#diff-8d705e6f1fb783dd6cf24de034dc5c7aac2e5e4187c06392075e3b4dd2688beaL1-R1) [[2]](diffhunk://#diff-8d705e6f1fb783dd6cf24de034dc5c7aac2e5e4187c06392075e3b4dd2688beaL18-R16) [[3]](diffhunk://#diff-8d705e6f1fb783dd6cf24de034dc5c7aac2e5e4187c06392075e3b4dd2688beaL40-R34) [[4]](diffhunk://#diff-8d705e6f1fb783dd6cf24de034dc5c7aac2e5e4187c06392075e3b4dd2688beaL179-L283)
- Exposes the new `linkedSharedDirs` API for external consumers. (`src/internal.ts` [src/internal.tsR42](diffhunk://#diff-ec5116fb1a8051593ae9bae15f9f6e50c736d07a59de8d680c62f8776f7ab166R42))

**Cache Invalidation and Linked Directory Tracking:**
- Integrates `linkedContentSignals` into the bundle cache key and output file naming, ensuring that changes in linked shared directories (e.g., npm-linked dev dependencies) properly invalidate the cache and trigger re-bundling. (`src/lib/core/build/bundle-shared.ts` [[1]](diffhunk://#diff-af77c096b4deddec353d29e8e28671d0abb39bb8365be8f79aa47bd318c64c0fR22) [[2]](diffhunk://#diff-af77c096b4deddec353d29e8e28671d0abb39bb8365be8f79aa47bd318c64c0fR90-L100) [[3]](diffhunk://#diff-af77c096b4deddec353d29e8e28671d0abb39bb8365be8f79aa47bd318c64c0fL148-R164) [[4]](diffhunk://#diff-af77c096b4deddec353d29e8e28671d0abb39bb8365be8f79aa47bd318c64c0fL330-R350)
- Adds logic to detect modified files that belong to shared packages and only re-bundle the affected externals, improving build performance and correctness. (`src/lib/core/build/rebuild-for-federation.ts` [[1]](diffhunk://#diff-3f4f1be801285c5343f622912778e1c47e4a45357a7f7697f83ba4f87d8aa4d7R13-R17) [[2]](diffhunk://#diff-3f4f1be801285c5343f622912778e1c47e4a45357a7f7697f83ba4f87d8aa4d7R28-R29) [[3]](diffhunk://#diff-3f4f1be801285c5343f622912778e1c47e4a45357a7f7697f83ba4f87d8aa4d7R85-R124)

**Testing:**
- Adds comprehensive tests for the affected-external re-bundling logic, covering scenarios where shared packages are modified, unchanged, or when no files are changed. (`src/lib/core/build/rebuild-for-federation.spec.ts` [src/lib/core/build/rebuild-for-federation.spec.tsR1-R91](diffhunk://#diff-97915636b95dff944e2b1e1b8edb6de1b29dcb78fa18036ca5d2606a23ec1563R1-R91))