### PR TITLE
perf(config): cache the transitive dependency expansion

### DIFF
--- a/src/lib/config/get-used-dependencies.spec.ts
+++ b/src/lib/config/get-used-dependencies.spec.ts
@@ -6,7 +6,7 @@ import {
   matchMapping,
   type UsedDependenciesDeps,
 } from './get-used-dependencies.js';
-import { createMemoryIo } from '../utils/io/__test-helpers__/memory-io.js';
+import { createMemoryIo, type MemoryIo } from '../utils/io/__test-helpers__/memory-io.js';
 import { createPackageJsonRepository } from '../utils/io/package-json-repository.js';
 
 describe('getUsedDependenciesFactoryCore', () => {
@@ -43,6 +43,58 @@ describe('getUsedDependenciesFactoryCore', () => {
 
     expect(used.external).toContain('rxjs');
     expect(used.external).toContain('@angular/core');
+  });
+
+  it('caches the transient peer expansion and reuses it on the next run', () => {
+    const files = {
+      '/ws/node_modules/a/package.json': JSON.stringify({ name: 'a', version: '1.0.0', main: 'index.js' }),
+      '/ws/node_modules/a/index.js': "export * from 'b';",
+      '/ws/node_modules/b/package.json': JSON.stringify({ name: 'b', version: '1.0.0', main: 'index.js' }),
+      '/ws/node_modules/b/index.js': '',
+    };
+    const projectData = {
+      'src/comp.ts': { externalLibraries: ['a'], imports: [], unresolvedImports: [] },
+    } as unknown as ProjectData;
+
+    const first = makeDeps(projectData, files);
+    const used = getUsedDependenciesFactoryCore(first, '/ws')({ exposes: { './Comp': { file: 'src/comp.ts' } }, sharedMappings: {} });
+    expect([...used.external].sort()).toEqual(['a', 'b']);
+
+    // Second run against the SAME io: the entry file no longer re-exports 'b',
+    // so a cache miss could not discover it through the peer graph again.
+    (first.io as MemoryIo).setFile('/ws/node_modules/a/index.js', '');
+    const cachedRun = getUsedDependenciesFactoryCore(first, '/ws')({ exposes: { './Comp': { file: 'src/comp.ts' } }, sharedMappings: {} });
+    expect([...cachedRun.external].sort()).toEqual(['a', 'b']);
+  });
+
+  it('invalidates the cached expansion when a visited package version changes', () => {
+    const files = {
+      '/ws/node_modules/a/package.json': JSON.stringify({ name: 'a', version: '1.0.0', main: 'index.js' }),
+      '/ws/node_modules/a/index.js': "export * from 'b';",
+      '/ws/node_modules/b/package.json': JSON.stringify({ name: 'b', version: '1.0.0', main: 'index.js' }),
+      '/ws/node_modules/b/index.js': '',
+    };
+    const projectData = {
+      'src/comp.ts': { externalLibraries: ['a'], imports: [], unresolvedImports: [] },
+    } as unknown as ProjectData;
+
+    const deps = makeDeps(projectData, files);
+    expect([...getUsedDependenciesFactoryCore(deps, '/ws')({ exposes: { './Comp': { file: 'src/comp.ts' } }, sharedMappings: {} }).external].sort()).toEqual([
+      'a',
+      'b',
+    ]);
+
+    // Upgrading 'a' must drop the cache, so the new peer graph is discovered.
+    const io = deps.io as MemoryIo;
+    io.setFile('/ws/node_modules/a/package.json', JSON.stringify({ name: 'a', version: '2.0.0', main: 'index.js' }));
+    io.setFile('/ws/node_modules/a/index.js', "export * from 'c';");
+    io.setFile('/ws/node_modules/c/package.json', JSON.stringify({ name: 'c', version: '1.0.0', main: 'index.js' }));
+    io.setFile('/ws/node_modules/c/index.js', '');
+
+    expect([...getUsedDependenciesFactoryCore(deps, '/ws')({ exposes: { './Comp': { file: 'src/comp.ts' } }, sharedMappings: {} }).external].sort()).toEqual([
+      'a',
+      'c',
+    ]);
   });
 
   it('discovers transient peer deps through the injected repo + io', () => {

--- a/src/lib/config/get-used-dependencies.ts
+++ b/src/lib/config/get-used-dependencies.ts
@@ -4,7 +4,12 @@ import { sharedPackageJsonRepository, getPackageInfo } from '../utils/package/pa
 import { type PackageJsonRepository } from '../domain/utils/package-json.contract.js';
 import { getExternalImportsCore } from './get-external-imports.js';
 import { nodeIo } from '../utils/io/node-io-adapter.js';
-import { type FileReaderPort } from '../domain/utils/io-port.contract.js';
+import {
+  type FileReaderPort,
+  type FileWriterPort,
+  type HashPort,
+} from '../domain/utils/io-port.contract.js';
+import { getDefaultCachePath } from '../core/cache/cache-persistence.js';
 import { type PathToImport } from '../domain/utils/mapped-path.contract.js';
 import { type UsedDependencies } from '../domain/utils/used-dependencies.contract.js';
 import { type ExposeEntry } from '../domain/config/federation-config.contract.js';
@@ -18,7 +23,7 @@ type GetProjectData = (
 ) => ProjectData;
 
 export interface UsedDependenciesDeps {
-  io: FileReaderPort;
+  io: FileReaderPort & FileWriterPort & HashPort;
   repo: PackageJsonRepository;
   getProjectData: GetProjectData;
 }
@@ -82,14 +87,74 @@ export function getUsedDependenciesFactoryCore(
   };
 }
 
+const TRANSIENT_DEPS_CACHE_FILE = 'used-transient-deps.meta.json';
+
+const transientDepsCacheFile = (workspaceRoot: string) =>
+  path.join(getDefaultCachePath(workspaceRoot), TRANSIENT_DEPS_CACHE_FILE);
+
+interface TransientDepsCacheEntry {
+  checksum: string;
+  /** Version of every package the previous expansion visited. */
+  versions: Record<string, string | null>;
+  result: string[];
+}
+
+/**
+ * Expanding the peer graph parses the entry point of every visited package,
+ * which dominates the cost of resolving used dependencies. The expansion is a
+ * pure function of the input package names and the contents of the visited
+ * packages, so it is cached across builds.
+ *
+ * Validation re-reads only the visited package versions — orders of magnitude
+ * cheaper than re-parsing their entry points — so a dependency upgrade still
+ * invalidates the entry. The cache lives under `node_modules/.cache`, so a
+ * reinstall drops it as well.
+ */
+function readCachedTransientDeps(
+  deps: UsedDependenciesDeps,
+  workspaceRoot: string,
+  checksum: string
+): Set<string> | undefined {
+  const file = transientDepsCacheFile(workspaceRoot);
+  if (!deps.io.exists(file)) {
+    return undefined;
+  }
+
+  let cached: TransientDepsCacheEntry;
+  try {
+    cached = JSON.parse(deps.io.readText(file)) as TransientDepsCacheEntry;
+  } catch {
+    return undefined;
+  }
+
+  if (cached.checksum !== checksum || !cached.result || !cached.versions) {
+    return undefined;
+  }
+
+  for (const [name, version] of Object.entries(cached.versions)) {
+    if ((getPackageInfo(name, workspaceRoot, deps.repo)?.version ?? null) !== version) {
+      return undefined;
+    }
+  }
+
+  return new Set(cached.result);
+}
+
 function addTransientDeps(
   packages: Set<string>,
   workspaceRoot: string,
   deps: UsedDependenciesDeps
 ) {
+  const checksum = deps.io.hash('sha256', [...packages].sort().join(':')).hex();
+  const cached = readCachedTransientDeps(deps, workspaceRoot, checksum);
+  if (cached) {
+    return cached;
+  }
+
   const packagesAndPeers = new Set<string>([...packages]);
   const discovered = new Set<string>(packagesAndPeers);
   const stack = [...packagesAndPeers];
+  const versions: Record<string, string | null> = {};
 
   while (stack.length > 0) {
     const dep = stack.pop();
@@ -104,6 +169,8 @@ function addTransientDeps(
       continue;
     }
 
+    versions[dep] = pInfo.version ?? null;
+
     const peerDeps = getExternalImportsCore(deps.io, pInfo.entryPoint);
 
     for (const peerDep of peerDeps) {
@@ -114,6 +181,16 @@ function addTransientDeps(
       }
     }
   }
+  try {
+    deps.io.mkdirp(getDefaultCachePath(workspaceRoot));
+    deps.io.writeText(
+      transientDepsCacheFile(workspaceRoot),
+      JSON.stringify({ checksum, versions, result: [...packagesAndPeers] })
+    );
+  } catch {
+    // A cache that cannot be written must never fail the build.
+  }
+
   return packagesAndPeers;
 }
 


### PR DESCRIPTION
## Problem

Resolving used dependencies runs on every build and every dev-server start, and it is never cached. On an Angular workspace with a host + 3 remotes it costs ~1s per application, paid again on every restart.

## Where the time actually goes

Splitting the phase on a real workspace (Angular 22.0.8, Kendo UI, 56 resolved packages):

| step | time |
| --- | --- |
| `getProjectData` (sheriff module-graph walk) | **143 ms** |
| `addTransientDeps` (peer expansion) | **860 ms** |
| total | ~1.0 s |

86% of the cost is not the graph walk — it is the peer expansion, which parses the entry point of every visited package to collect its external imports.

## Fix

Cache the peer expansion only. It is a pure function of the input package names and the contents of the visited packages, so it can be cached across builds:

- **Key** — sha256 of the sorted input package names.
- **Validation** — the entry records the version of every package the previous expansion visited; on read those versions are re-checked. Reading 56 package versions takes **4 ms**, roughly 1/200 of re-parsing their entry points, so validation is effectively free.
- **Location** — `node_modules/.cache/native-federation`, so a reinstall drops the entry as well.

The sheriff walk still runs on every build, so source changes are picked up exactly as before. Only the `node_modules` crawl is reused.

Writing the cache is wrapped in `try/catch`: a cache that cannot be written must never fail the build.

`UsedDependenciesDeps.io` is widened from `FileReaderPort` to `FileReaderPort & FileWriterPort & HashPort` to write and hash. `defaultDeps` already passes `nodeIo` (an `IoPort`), and the existing specs already inject a full `createMemoryIo()`, so no call site changes.

I deliberately did **not** reuse `cacheEntryCore`: its `CacheMetadata` type is bound to bundle artifacts (`externals`, `files`, `copyFiles`). Widening it for an unrelated payload seemed worse than a small self-contained read/write here; only `getDefaultCachePath` is shared.

## Results

| | time |
| --- | --- |
| used-dependency resolution, cold | **1060 ms** |
| cached | **88–95 ms** |

The resolved set is byte-identical across both paths (56 packages).

End-to-end on a real dev server, using the **built** artifact rather than source:

```
cache empty : "Removed unused dependencies." 2.08s  → server ready 9.73s
cache warm  : "Removed unused dependencies." 1.05s  → server ready 8.60s
```

Bundle output is unchanged (6232.5 KiB raw / 1329.4 KiB gzip before and after).

Invalidation was verified by bumping a visited package's version in `node_modules`: the cached entry was dropped (91 ms → 997 ms) and re-established on the following run.

## Tests

Two specs added to `get-used-dependencies.spec.ts`:

- the expansion is reused on a second run — proven by emptying the entry file in between, so a cache miss could no longer discover the peer;
- the entry is invalidated when a visited package's version changes, and the new peer graph is picked up.

`vitest run` passes 312 tests across 41 files, `tsc --noEmit` is clean, and `eslint src` reports 0 errors with the warning count unchanged from the unmodified baseline.
