### PR TITLE
fix: Key the externals cache on installed dependency versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,18 +147,25 @@ The library supports **watch mode** for development:
 
 Native Federation uses an intelligent caching system to speed up builds:
 
-**Federation Cache** (`src/lib/core/federation-cache.ts`):
+**Externals cache** (`src/lib/core/cache/cache-persistence.ts`) — on disk, across builds:
 
-- Caches built shared dependencies by content hash
-- Reuses cached bundles when dependencies haven't changed
-- Stored in `node_modules/.federation` by default
-- Persisted across builds for fast rebuilds
+- Caches the bundled shared dependencies of each bundle, alongside a `.meta.json` describing them
+- Keyed by a checksum over the external names, their installed versions, the builder version and
+  the relevant feature flags (`getChecksum`)
+- Stored in `node_modules/.cache/native-federation` by default (`getDefaultCachePath`)
+- On a checksum match the cached artifacts are copied straight into the output path
+
+**Federation cache** (`src/lib/core/cache/federation-cache.ts`) — in memory, one build:
+
+- Accumulates the externals, chunks and integrity hashes that go into `remoteEntry.json`
 
 **Cache invalidation**:
 
-- Based on package version changes
-- Based on configuration changes
-- Can be manually cleared
+- Based on the installed versions of shared packages, not their declared ranges
+  (`installedVersions`)
+- Based on configuration changes and on the builder version
+- For symlinked (npm-linked) deps, additionally on a content signal (max mtime of the package dir)
+- Can be cleared by deleting the cache folder
 
 ## Testing
 
@@ -217,7 +224,7 @@ Native Federation uses an intelligent caching system to speed up builds:
 
 1. Check `federation.config.js` configuration
 2. Verify externals are properly excluded
-3. Check federation cache in `node_modules/.federation`
+3. Check the externals cache in `node_modules/.cache/native-federation`
 4. Enable verbose logging in `federationBuilder.init({ options: { verbose: true } })`
 5. Look at generated `remoteEntry.json` files
 6. Check the import map in browser DevTools

--- a/src/lib/core/build/bundle-shared.spec.ts
+++ b/src/lib/core/build/bundle-shared.spec.ts
@@ -9,7 +9,10 @@ import {
   readBuilderPackageJson,
 } from './bundle-shared.js';
 import { createMemoryIo } from '../../utils/io/__test-helpers__/memory-io.js';
-import { createFakeBuildAdapter } from './__test-helpers__/fake-build-adapter.js';
+import {
+  createFakeBuildAdapter,
+  type FakeBuildAdapter,
+} from './__test-helpers__/fake-build-adapter.js';
 import { prepareSkipList } from '../../config/default-skip-list.js';
 import type { PackageJsonRepository } from '../../domain/utils/package-json.contract.js';
 import type { IoPort } from '../../domain/utils/io-port.contract.js';
@@ -487,9 +490,9 @@ describe('bundleSharedCore (via injected io, repo and build adapter)', () => {
     expect(await buildWith(false)).toBe(await buildWith(true));
   });
 
-  // The shareAll shape: no `version` on the config and no configured packageInfo, so the
-  // installed version is the only thing that can tell two builds apart.
-  const inferredFoo = (): Record<string, NormalizedExternalConfig> => ({
+  const fooWith = (
+    extra: Partial<NormalizedExternalConfig> = {}
+  ): Record<string, NormalizedExternalConfig> => ({
     foo: {
       singleton: true,
       strictVersion: false,
@@ -497,6 +500,7 @@ describe('bundleSharedCore (via injected io, repo and build adapter)', () => {
       chunks: false,
       platform: 'browser',
       build: 'default',
+      ...extra,
     },
   });
 
@@ -507,11 +511,15 @@ describe('bundleSharedCore (via injected io, repo and build adapter)', () => {
     exists: () => false,
   });
 
-  const cachedBuild = async (mem: ReturnType<typeof createMemoryIo>, version: string) => {
+  const cachedBuild = async (
+    mem: ReturnType<typeof createMemoryIo>,
+    version: string,
+    sharedBundles: Record<string, NormalizedExternalConfig> = fooWith()
+  ) => {
     const adapter = createFakeBuildAdapter({ io: mem });
     const result = await bundleSharedCore(
       { io: mem, repo: repoAtVersion(version), adapter },
-      inferredFoo(),
+      sharedBundles,
       makeConfig(),
       makeFedOptions({ cacheExternalArtifacts: true }),
       [],
@@ -520,23 +528,90 @@ describe('bundleSharedCore (via injected io, repo and build adapter)', () => {
     return { adapter, result };
   };
 
-  it('re-uses the cached externals when the installed version is unchanged', async () => {
-    const mem = createMemoryIo().setFile(ROOT_PKG, '{}');
+  // All three config styles must invalidate on an installed-version bump. `shareAll` and
+  // `requiredVersion: 'auto'` leave `version` unset; an explicit range pins it to something that
+  // stays constant across the bump — which is exactly how the stale bundle used to survive.
+  const CONFIG_STYLES: Array<[string, Record<string, NormalizedExternalConfig>]> = [
+    ['shareAll (no declared version)', fooWith()],
+    ["share + requiredVersion 'auto'", fooWith({ requiredVersion: 'auto' })],
+    ['share + explicit declared range', fooWith({ version: '^2.0.0' })],
+  ];
 
-    await cachedBuild(mem, '2.0.0');
-    const { adapter, result } = await cachedBuild(mem, '2.0.0');
+  describe.each(CONFIG_STYLES)('installed-version invalidation — %s', (_label, sharedBundles) => {
+    it('re-uses the cached externals when the installed version is unchanged', async () => {
+      const mem = createMemoryIo().setFile(ROOT_PKG, '{}');
 
-    expect(adapter.calls.setup).toHaveLength(0);
-    expect(result.externals[0]).toMatchObject({ packageName: 'foo', version: '2.0.0' });
+      await cachedBuild(mem, '2.0.0', sharedBundles);
+      const { adapter, result } = await cachedBuild(mem, '2.0.0', sharedBundles);
+
+      expect(adapter.calls.setup).toHaveLength(0);
+      expect(result.externals[0]).toMatchObject({ packageName: 'foo', version: '2.0.0' });
+    });
+
+    it('rebuilds when the installed version changed under an unchanged config', async () => {
+      const mem = createMemoryIo().setFile(ROOT_PKG, '{}');
+
+      await cachedBuild(mem, '2.0.0', sharedBundles);
+      const { adapter, result } = await cachedBuild(mem, '2.0.1', sharedBundles);
+
+      expect(adapter.calls.setup).toHaveLength(1);
+      expect(result.externals[0]).toMatchObject({ packageName: 'foo', version: '2.0.1' });
+    });
   });
 
-  it('rebuilds when the installed version changed under an unchanged config', async () => {
+  // A configured packageInfo makes the build skip node_modules entirely, so the key must not
+  // track it either — even when that packageInfo carries no version of its own. The missing
+  // `version` is reachable in practice: ExternalConfig declares it optional and
+  // with-native-federation.ts:99 casts rather than defaulting it.
+  it('ignores the installed version when packageInfo is configured without a version', async () => {
     const mem = createMemoryIo().setFile(ROOT_PKG, '{}');
+    const configured = fooWith({
+      packageInfo: { entryPoint: 'foo/vendored.js', esm: true } as NonNullable<
+        NormalizedExternalConfig['packageInfo']
+      >,
+    });
 
-    await cachedBuild(mem, '2.0.0');
-    const { adapter, result } = await cachedBuild(mem, '2.0.1');
+    await cachedBuild(mem, '2.0.0', configured);
+    const { adapter } = await cachedBuild(mem, '2.0.1', configured);
 
-    expect(adapter.calls.setup).toHaveLength(1);
-    expect(result.externals[0]).toMatchObject({ packageName: 'foo', version: '2.0.1' });
+    expect(adapter.calls.setup).toHaveLength(0);
+  });
+
+  // copyFiles runs on the fresh-build path too, so every name in the persisted metadata must
+  // exist in the cache dir. Sourcemaps are the risky case: rewriteImports renames the entry to a
+  // content hash and deletes the original, while the .map keeps its version-based name.
+  it('copies sourcemaps alongside content-hashed entries without tripping the missing-file guard', async () => {
+    const mem = createMemoryIo().setFile(ROOT_PKG, '{}');
+    const adapter: FakeBuildAdapter = createFakeBuildAdapter({
+      io: mem,
+      results: name => {
+        const setup = [...adapter.calls.setup].reverse().find(s => s.name === name)!;
+        return setup.options.entryPoints.flatMap(ep => [
+          { fileName: path.join(setup.options.outdir, ep.outName) },
+          { fileName: path.join(setup.options.outdir, `${ep.outName}.map`) },
+        ]);
+      },
+    });
+
+    const result = await bundleSharedCore(
+      { io: mem, repo: repoAtVersion('2.0.0'), adapter },
+      fooWith(),
+      makeConfig(),
+      makeFedOptions({ cacheExternalArtifacts: true }),
+      [],
+      BUILD_OPTIONS
+    );
+
+    const outFileName = result.externals[0]!.outFileName;
+    expect(mem.isFile(path.join('/ws/dist', outFileName))).toBe(true);
+
+    const persisted: { files: string[] } = JSON.parse(
+      mem.readText(path.join('/cache', 'shared.meta.json'))
+    );
+    expect(persisted.files).toContain(outFileName);
+    expect(persisted.files.filter(f => f.endsWith('.map'))).toHaveLength(1);
+    for (const file of persisted.files) {
+      expect(mem.isFile(path.join('/ws/dist', file))).toBe(true);
+    }
   });
 });

--- a/src/lib/core/build/bundle-shared.spec.ts
+++ b/src/lib/core/build/bundle-shared.spec.ts
@@ -486,4 +486,57 @@ describe('bundleSharedCore (via injected io, repo and build adapter)', () => {
     // denseExternals must not participate in the bundler cache key: identical output name.
     expect(await buildWith(false)).toBe(await buildWith(true));
   });
+
+  // The shareAll shape: no `version` on the config and no configured packageInfo, so the
+  // installed version is the only thing that can tell two builds apart.
+  const inferredFoo = (): Record<string, NormalizedExternalConfig> => ({
+    foo: {
+      singleton: true,
+      strictVersion: false,
+      requiredVersion: '^2.0.0',
+      chunks: false,
+      platform: 'browser',
+      build: 'default',
+    },
+  });
+
+  const repoAtVersion = (version: string): PackageJsonRepository => ({
+    getPackageJsonFiles: () => [{ content: {}, directory: '/ws' }],
+    findDepPackageJson: () => '/ws/node_modules/foo/package.json',
+    readJson: () => ({ version, type: 'module', module: './index.mjs' }),
+    exists: () => false,
+  });
+
+  const cachedBuild = async (mem: ReturnType<typeof createMemoryIo>, version: string) => {
+    const adapter = createFakeBuildAdapter({ io: mem });
+    const result = await bundleSharedCore(
+      { io: mem, repo: repoAtVersion(version), adapter },
+      inferredFoo(),
+      makeConfig(),
+      makeFedOptions({ cacheExternalArtifacts: true }),
+      [],
+      BUILD_OPTIONS
+    );
+    return { adapter, result };
+  };
+
+  it('re-uses the cached externals when the installed version is unchanged', async () => {
+    const mem = createMemoryIo().setFile(ROOT_PKG, '{}');
+
+    await cachedBuild(mem, '2.0.0');
+    const { adapter, result } = await cachedBuild(mem, '2.0.0');
+
+    expect(adapter.calls.setup).toHaveLength(0);
+    expect(result.externals[0]).toMatchObject({ packageName: 'foo', version: '2.0.0' });
+  });
+
+  it('rebuilds when the installed version changed under an unchanged config', async () => {
+    const mem = createMemoryIo().setFile(ROOT_PKG, '{}');
+
+    await cachedBuild(mem, '2.0.0');
+    const { adapter, result } = await cachedBuild(mem, '2.0.1');
+
+    expect(adapter.calls.setup).toHaveLength(1);
+    expect(result.externals[0]).toMatchObject({ packageName: 'foo', version: '2.0.1' });
+  });
 });

--- a/src/lib/core/build/bundle-shared.ts
+++ b/src/lib/core/build/bundle-shared.ts
@@ -3,6 +3,7 @@ import type { NormalizedFederationConfig } from '../../domain/config/federation-
 import {
   sharedPackageJsonRepository,
   getPackageInfo,
+  installedVersions,
   type PackageInfo,
 } from '../../utils/package/package-info.js';
 import type { PackageJsonRepository } from '../../domain/utils/package-json.contract.js';
@@ -98,13 +99,20 @@ export async function bundleSharedCore(
     deps.repo
   );
 
+  const resolvedVersions = installedVersions(Object.keys(sharedBundles), folder, deps.repo);
+  // A configured packageInfo short-circuits resolution below, so the key must follow that source.
+  for (const [key, cfg] of Object.entries(sharedBundles)) {
+    if (cfg.packageInfo?.version) resolvedVersions[key] = cfg.packageInfo.version;
+  }
+
   const checksum = getChecksumCore(
     deps.io,
     sharedBundles,
     fedOptions.dev ? '1' : '0',
     builderVersion,
     config.features.synthesizeCjsExports,
-    contentSignals
+    contentSignals,
+    resolvedVersions
   );
 
   const bundleCache = cacheEntryCore(

--- a/src/lib/core/build/bundle-shared.ts
+++ b/src/lib/core/build/bundle-shared.ts
@@ -111,7 +111,7 @@ export async function bundleSharedCore(
     sharedBundles,
     fedOptions.dev ? '1' : '0',
     builderVersion,
-    config.features.synthesizeCjsExports,
+    config.features,
     contentSignals,
     resolvedVersions
   );

--- a/src/lib/core/build/bundle-shared.ts
+++ b/src/lib/core/build/bundle-shared.ts
@@ -100,9 +100,10 @@ export async function bundleSharedCore(
   );
 
   const resolvedVersions = installedVersions(Object.keys(sharedBundles), folder, deps.repo);
-  // A configured packageInfo short-circuits resolution below, so the key must follow that source.
+  // A configured packageInfo short-circuits resolution below, so the key must follow that source —
+  // including when it carries no version, where node_modules cannot affect the bundled bytes.
   for (const [key, cfg] of Object.entries(sharedBundles)) {
-    if (cfg.packageInfo?.version) resolvedVersions[key] = cfg.packageInfo.version;
+    if (cfg.packageInfo) resolvedVersions[key] = cfg.packageInfo.version ?? '';
   }
 
   const checksum = getChecksumCore(

--- a/src/lib/core/cache/cache-persistence.spec.ts
+++ b/src/lib/core/cache/cache-persistence.spec.ts
@@ -56,39 +56,102 @@ describe('getChecksumCore', () => {
     );
   });
 
-  it('changes when the CJS-export synthesis flag changes', () => {
+  it('changes when any single feature flag flips', () => {
     const base = { react: ext('18') };
-    expect(getChecksumCore(io, base, '0', '1.0.0', true)).not.toBe(
-      getChecksumCore(io, base, '0', '1.0.0', false)
+    const flags = {
+      mappingVersion: false,
+      ignoreUnusedDeps: false,
+      denseChunking: false,
+      denseExternals: false,
+      integrityHashes: false,
+      synthesizeCjsExports: false,
+    };
+    const allOff = getChecksumCore(io, base, '0', '1.0.0', flags);
+
+    for (const flag of Object.keys(flags) as Array<keyof typeof flags>) {
+      expect(getChecksumCore(io, base, '0', '1.0.0', { ...flags, [flag]: true })).not.toBe(allOff);
+    }
+  });
+
+  // A flag present-and-false must not hash like a flag absent: adding a flag to the contract has
+  // to invalidate, even when it defaults off.
+  it('distinguishes an explicitly disabled flag from an absent one', () => {
+    const base = { react: ext('18') };
+    expect(getChecksumCore(io, base, '0', '1.0.0', { denseChunking: false })).not.toBe(
+      getChecksumCore(io, base, '0', '1.0.0', {})
     );
+  });
+
+  // These five reach remoteEntry.json via buildResult, and a cache hit replays the recorded
+  // externals verbatim — so each has to invalidate or the runtime gets stale negotiation metadata.
+  describe.each([
+    ['requiredVersion', { requiredVersion: '^2.0.0' }, { requiredVersion: '>=2.0.0' }],
+    ['singleton', { singleton: true }, { singleton: false }],
+    ['strictVersion', { strictVersion: true }, { strictVersion: false }],
+    ['shareScope', { shareScope: 'a' }, { shareScope: 'b' }],
+    ['pool', { pool: 'critical' }, { pool: 'lazy' }],
+  ])('shared-info field %s', (_field, left, right) => {
+    it('changes the checksum when it changes', () => {
+      const at = (over: Partial<NormalizedExternalConfig>) =>
+        getChecksumCore(io, { react: { ...ext('18'), ...over } }, '0');
+
+      expect(at(left)).not.toBe(at(right));
+    });
+
+    it('is stable when it does not', () => {
+      const at = (over: Partial<NormalizedExternalConfig>) =>
+        getChecksumCore(io, { react: { ...ext('18'), ...over } }, '0');
+
+      expect(at(left)).toBe(at(left));
+    });
+  });
+
+  // `singleton: false` and an absent `singleton` mean different things downstream, so they must
+  // not collide the way a plain falsy check would make them.
+  it('distinguishes an explicitly false shared-info field from an absent one', () => {
+    expect(getChecksumCore(io, { react: { ...ext('18'), singleton: false } }, '0')).not.toBe(
+      getChecksumCore(io, { react: ext('18') }, '0')
+    );
+  });
+
+  it('is independent of feature-flag key insertion order', () => {
+    const base = { react: ext('18') };
+    expect(
+      getChecksumCore(io, base, '0', '1.0.0', { denseChunking: true, mappingVersion: false })
+    ).toBe(getChecksumCore(io, base, '0', '1.0.0', { mappingVersion: false, denseChunking: true }));
   });
 
   it('matches a hand-computed sha256', () => {
     const expected = crypto
       .createHash('sha256')
-      .update('deps:react@18:dev=0:builder=2.0.0:cjs=1')
+      .update('deps:react@18:dev=0:builder=2.0.0:features=denseChunking=1,mappingVersion=0')
       .digest('hex');
-    expect(getChecksumCore(io, { react: ext('18') }, '0', '2.0.0')).toBe(expected);
+    expect(
+      getChecksumCore(io, { react: ext('18') }, '0', '2.0.0', {
+        mappingVersion: false,
+        denseChunking: true,
+      })
+    ).toBe(expected);
   });
 
   // Registry-dep regression guard: an empty content-signal map must not perturb the hash.
   it('is byte-identical whether contentSignals is omitted or empty', () => {
     const base = { react: ext('18') };
-    expect(getChecksumCore(io, base, '0', '2.0.0', true, {})).toBe(
+    expect(getChecksumCore(io, base, '0', '2.0.0', {}, {})).toBe(
       getChecksumCore(io, base, '0', '2.0.0')
     );
   });
 
   it('changes when a content signal is added for a (linked) package', () => {
     const base = { '@scope/lib': ext('1.0.0') };
-    expect(getChecksumCore(io, base, '0', '', true, { '@scope/lib': '111' })).not.toBe(
+    expect(getChecksumCore(io, base, '0', '', {}, { '@scope/lib': '111' })).not.toBe(
       getChecksumCore(io, base, '0')
     );
   });
 
   it('is byte-identical whether resolvedVersions is omitted or empty', () => {
     const base = { react: ext('18') };
-    expect(getChecksumCore(io, base, '0', '2.0.0', true, {}, {})).toBe(
+    expect(getChecksumCore(io, base, '0', '2.0.0', {}, {}, {})).toBe(
       getChecksumCore(io, base, '0', '2.0.0')
     );
   });
@@ -97,23 +160,24 @@ describe('getChecksumCore', () => {
   // installed version is the only thing that can distinguish two builds.
   it('changes when the installed version changes and the declared one does not', () => {
     const base = { react: ext() };
-    expect(getChecksumCore(io, base, '0', '', true, {}, { react: '18.0.0' })).not.toBe(
-      getChecksumCore(io, base, '0', '', true, {}, { react: '18.0.8' })
+    expect(getChecksumCore(io, base, '0', '', {}, {}, { react: '18.0.0' })).not.toBe(
+      getChecksumCore(io, base, '0', '', {}, {}, { react: '18.0.8' })
     );
   });
 
-  // Declared and installed occupy separate slots, so one cannot be mistaken for the other.
+  // One slot, but a distinct sigil per source: a key that goes from unresolvable-with-a-declared
+  // range to actually installed at that same string must still invalidate.
   it('distinguishes a declared version from the same string as an installed one', () => {
     expect(getChecksumCore(io, { react: ext('18.0.0') }, '0')).not.toBe(
-      getChecksumCore(io, { react: ext() }, '0', '', true, {}, { react: '18.0.0' })
+      getChecksumCore(io, { react: ext() }, '0', '', {}, {}, { react: '18.0.0' })
     );
   });
 
   it('changes when a content signal changes but is stable when it does not', () => {
     const base = { '@scope/lib': ext('1.0.0') };
-    const a = getChecksumCore(io, base, '0', '', true, { '@scope/lib': '111' });
-    const b = getChecksumCore(io, base, '0', '', true, { '@scope/lib': '222' });
-    const aAgain = getChecksumCore(io, base, '0', '', true, { '@scope/lib': '111' });
+    const a = getChecksumCore(io, base, '0', '', {}, { '@scope/lib': '111' });
+    const b = getChecksumCore(io, base, '0', '', {}, { '@scope/lib': '222' });
+    const aAgain = getChecksumCore(io, base, '0', '', {}, { '@scope/lib': '111' });
     expect(a).not.toBe(b);
     expect(a).toBe(aAgain);
   });

--- a/src/lib/core/cache/cache-persistence.spec.ts
+++ b/src/lib/core/cache/cache-persistence.spec.ts
@@ -139,17 +139,26 @@ describe('cacheEntryCore', () => {
     expect(entry.getMetadata('sum1')).toBeUndefined();
   });
 
-  it('copyFiles creates the output dir and copies only existing files', () => {
+  it('copyFiles creates the output dir and copies the recorded files', () => {
     const io = createMemoryIo()
       .setFile('/cache/a.js', 'A')
-      .setFile('/cache/x.meta.json', JSON.stringify(meta({ files: ['a.js', 'missing.js'] })));
+      .setFile('/cache/x.meta.json', JSON.stringify(meta({ files: ['a.js'] })));
     const entry = cacheEntryCore(io, '/cache', 'x.meta.json');
 
     entry.copyFiles('/dist');
 
     expect(io.isFile('/dist/a.js')).toBe(true);
     expect(io.readText('/dist/a.js')).toBe('A');
-    expect(io.isFile('/dist/missing.js')).toBe(false);
+  });
+
+  // A reaped cache used to degrade into a silently incomplete dist.
+  it('copyFiles throws when a recorded file is missing from the cache', () => {
+    const io = createMemoryIo()
+      .setFile('/cache/a.js', 'A')
+      .setFile('/cache/x.meta.json', JSON.stringify(meta({ files: ['a.js', 'missing.js'] })));
+    const entry = cacheEntryCore(io, '/cache', 'x.meta.json');
+
+    expect(() => entry.copyFiles('/dist')).toThrow(/'missing\.js'.*is missing/);
   });
 
   it('copyFiles throws when metadata is missing', () => {

--- a/src/lib/core/cache/cache-persistence.spec.ts
+++ b/src/lib/core/cache/cache-persistence.spec.ts
@@ -86,6 +86,29 @@ describe('getChecksumCore', () => {
     );
   });
 
+  it('is byte-identical whether resolvedVersions is omitted or empty', () => {
+    const base = { react: ext('18') };
+    expect(getChecksumCore(io, base, '0', '2.0.0', true, {}, {})).toBe(
+      getChecksumCore(io, base, '0', '2.0.0')
+    );
+  });
+
+  // The bug this guards: with shareAll the declared version is absent from `shared`, so the
+  // installed version is the only thing that can distinguish two builds.
+  it('changes when the installed version changes and the declared one does not', () => {
+    const base = { react: ext() };
+    expect(getChecksumCore(io, base, '0', '', true, {}, { react: '18.0.0' })).not.toBe(
+      getChecksumCore(io, base, '0', '', true, {}, { react: '18.0.8' })
+    );
+  });
+
+  // Declared and installed occupy separate slots, so one cannot be mistaken for the other.
+  it('distinguishes a declared version from the same string as an installed one', () => {
+    expect(getChecksumCore(io, { react: ext('18.0.0') }, '0')).not.toBe(
+      getChecksumCore(io, { react: ext() }, '0', '', true, {}, { react: '18.0.0' })
+    );
+  });
+
   it('changes when a content signal changes but is stable when it does not', () => {
     const base = { '@scope/lib': ext('1.0.0') };
     const a = getChecksumCore(io, base, '0', '', true, { '@scope/lib': '111' });

--- a/src/lib/core/cache/cache-persistence.ts
+++ b/src/lib/core/cache/cache-persistence.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import type { NormalizedExternalConfig } from '../../domain/config/external-config.contract.js';
+import type { NormalizedFederationConfig } from '../../domain/config/federation-config.contract.js';
 import type {
   ChunkInfo,
   IntegrityMap,
@@ -25,44 +26,71 @@ export const getChecksum = (
   shared: Record<string, NormalizedExternalConfig>,
   dev: '1' | '0',
   builderVersion = '',
-  synthesizeCjsExports = true,
+  features: FeatureFlags = {},
   contentSignals: Record<string, string> = {},
   resolvedVersions: Record<string, string> = {}
 ): string =>
-  getChecksumCore(
-    nodeIo,
-    shared,
-    dev,
-    builderVersion,
-    synthesizeCjsExports,
-    contentSignals,
-    resolvedVersions
-  );
+  getChecksumCore(nodeIo, shared, dev, builderVersion, features, contentSignals, resolvedVersions);
+
+type FeatureFlags = Partial<NormalizedFederationConfig['features']>;
+
+// Every flag participates, sorted by name so the record's key order cannot perturb the hash.
+// Deliberately not cherry-picked to the flags that reach the bundler: a flag that turns out to
+// affect the bundled bytes is a correctness bug, whereas one that does not costs a single
+// needless rebuild on the rare occasion someone toggles it.
+const featureState = (features: FeatureFlags): string =>
+  Object.entries(features)
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([flag, on]) => `${flag}=${on ? '1' : '0'}`)
+    .join(',');
+
+// Fields `buildResult` copies from the config straight into SharedInfo, so they ship in
+// remoteEntry.json. A cache hit replays the recorded externals verbatim, so a change to any of
+// them must miss — otherwise the runtime negotiates versions against stale metadata.
+const SHARED_INFO_FIELDS = [
+  'requiredVersion',
+  'singleton',
+  'strictVersion',
+  'shareScope',
+  'pool',
+] as const;
+
+// JSON-encoded so a value containing a delimiter cannot forge one; fixed field order, so no sort.
+const sharedInfoState = (config: NormalizedExternalConfig): string => {
+  const values = SHARED_INFO_FIELDS.map(field => config[field] ?? null);
+  return values.every(value => value === null) ? '' : `!${JSON.stringify(values)}`;
+};
 
 export const getChecksumCore = (
   hash: HashPort,
   shared: Record<string, NormalizedExternalConfig>,
   dev: '1' | '0',
   builderVersion = '',
-  synthesizeCjsExports = true,
+  features: FeatureFlags = {},
   // Per-key content signal, set only for symlinked deps; empty map => version-only hash.
   contentSignals: Record<string, string> = {},
-  // Per-key installed version. `shared[].version` is the declared range and is absent on the
-  // shareAll path, so this is what actually ties the key to what is in node_modules.
+  // Per-key installed version — the only version that can change the bundled bytes, so it wins
+  // outright. An omitted map falls back to the declared range for every key, reproducing the
+  // pre-installed-version checksum byte for byte.
   resolvedVersions: Record<string, string> = {}
 ): string => {
   const denseExternals = Object.keys(shared)
     .sort()
     .reduce((clean, external) => {
-      const version = shared[external]!.version ? `@${shared[external]!.version}` : '';
-      const resolved = resolvedVersions[external] ? `~${resolvedVersions[external]}` : '';
+      const installed = resolvedVersions[external];
+      const declared = shared[external]!.version;
+      // Distinct sigils: a version read from node_modules must never hash like the same string
+      // merely declared, or a key going from unresolvable to installed would look unchanged.
+      const version = installed ? `~${installed}` : declared ? `@${declared}` : '';
       const signal = contentSignals[external] ? `#${contentSignals[external]}` : '';
-      return clean + ':' + external + version + resolved + signal;
+      return clean + ':' + external + version + sharedInfoState(shared[external]!) + signal;
     }, 'deps');
 
-  const cjs = synthesizeCjsExports ? '1' : '0';
   return hash
-    .hash('sha256', denseExternals + `:dev=${dev}:builder=${builderVersion}:cjs=${cjs}`)
+    .hash(
+      'sha256',
+      denseExternals + `:dev=${dev}:builder=${builderVersion}:features=${featureState(features)}`
+    )
     .hex();
 };
 

--- a/src/lib/core/cache/cache-persistence.ts
+++ b/src/lib/core/cache/cache-persistence.ts
@@ -100,8 +100,12 @@ export const cacheEntryCore = (io: CachePort, pathToCache: string, fileName: str
 
       cachedResult.files.forEach(file => {
         const cachedFile = path.join(pathToCache, file);
-        const distFileName = path.join(fullOutputPath, file);
-        if (io.exists(cachedFile)) io.copyFile(cachedFile, distFileName);
+        if (!io.exists(cachedFile))
+          throw new Error(
+            `Cached artifact '${file}' recorded in '${metadataFile}' is missing. ` +
+              `Delete '${pathToCache}' and rebuild.`
+          );
+        io.copyFile(cachedFile, path.join(fullOutputPath, file));
       });
     },
     clear: () => {

--- a/src/lib/core/cache/cache-persistence.ts
+++ b/src/lib/core/cache/cache-persistence.ts
@@ -32,12 +32,8 @@ export const getChecksum = (
 ): string =>
   getChecksumCore(nodeIo, shared, dev, builderVersion, features, contentSignals, resolvedVersions);
 
-type FeatureFlags = Partial<NormalizedFederationConfig['features']>;
+export type FeatureFlags = Partial<NormalizedFederationConfig['features']>;
 
-// Every flag participates, sorted by name so the record's key order cannot perturb the hash.
-// Deliberately not cherry-picked to the flags that reach the bundler: a flag that turns out to
-// affect the bundled bytes is a correctness bug, whereas one that does not costs a single
-// needless rebuild on the rare occasion someone toggles it.
 const featureState = (features: FeatureFlags): string =>
   Object.entries(features)
     .sort(([a], [b]) => (a < b ? -1 : 1))
@@ -79,8 +75,7 @@ export const getChecksumCore = (
     .reduce((clean, external) => {
       const installed = resolvedVersions[external];
       const declared = shared[external]!.version;
-      // Distinct sigils: a version read from node_modules must never hash like the same string
-      // merely declared, or a key going from unresolvable to installed would look unchanged.
+
       const version = installed ? `~${installed}` : declared ? `@${declared}` : '';
       const signal = contentSignals[external] ? `#${contentSignals[external]}` : '';
       return clean + ':' + external + version + sharedInfoState(shared[external]!) + signal;

--- a/src/lib/core/cache/cache-persistence.ts
+++ b/src/lib/core/cache/cache-persistence.ts
@@ -26,9 +26,18 @@ export const getChecksum = (
   dev: '1' | '0',
   builderVersion = '',
   synthesizeCjsExports = true,
-  contentSignals: Record<string, string> = {}
+  contentSignals: Record<string, string> = {},
+  resolvedVersions: Record<string, string> = {}
 ): string =>
-  getChecksumCore(nodeIo, shared, dev, builderVersion, synthesizeCjsExports, contentSignals);
+  getChecksumCore(
+    nodeIo,
+    shared,
+    dev,
+    builderVersion,
+    synthesizeCjsExports,
+    contentSignals,
+    resolvedVersions
+  );
 
 export const getChecksumCore = (
   hash: HashPort,
@@ -37,14 +46,18 @@ export const getChecksumCore = (
   builderVersion = '',
   synthesizeCjsExports = true,
   // Per-key content signal, set only for symlinked deps; empty map => version-only hash.
-  contentSignals: Record<string, string> = {}
+  contentSignals: Record<string, string> = {},
+  // Per-key installed version. `shared[].version` is the declared range and is absent on the
+  // shareAll path, so this is what actually ties the key to what is in node_modules.
+  resolvedVersions: Record<string, string> = {}
 ): string => {
   const denseExternals = Object.keys(shared)
     .sort()
     .reduce((clean, external) => {
       const version = shared[external]!.version ? `@${shared[external]!.version}` : '';
+      const resolved = resolvedVersions[external] ? `~${resolvedVersions[external]}` : '';
       const signal = contentSignals[external] ? `#${contentSignals[external]}` : '';
-      return clean + ':' + external + version + signal;
+      return clean + ':' + external + version + resolved + signal;
     }, 'deps');
 
   const cjs = synthesizeCjsExports ? '1' : '0';

--- a/src/lib/utils/package/package-info.spec.ts
+++ b/src/lib/utils/package/package-info.spec.ts
@@ -5,6 +5,7 @@ import {
   tryGetPackageInfo,
   getVersionMaps,
   findDepPackageJson,
+  installedVersions,
 } from './package-info.js';
 import { createPackageJsonRepository } from '../io/package-json-repository.js';
 import { createMemoryIo } from '../io/__test-helpers__/memory-io.js';
@@ -68,5 +69,74 @@ describe('package-info facade (with injected repository)', () => {
 
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
+  });
+});
+
+describe('installedVersions', () => {
+  const versionsIo = () =>
+    createMemoryIo()
+      .setFile(path.join(WS, 'package.json'), JSON.stringify({ dependencies: {} }))
+      .setFile(
+        path.join(WS, 'node_modules/@scope/lib/package.json'),
+        JSON.stringify({ version: '2.5.0', module: './index.mjs' })
+      )
+      // Secondary entry points ship their own package.json, typically without a version:
+      // the root's version is what PackageInfo records for them.
+      .setFile(
+        path.join(WS, 'node_modules/@scope/lib/testing/package.json'),
+        JSON.stringify({ module: './index.mjs' })
+      )
+      .setFile(
+        path.join(WS, 'node_modules/react/package.json'),
+        JSON.stringify({ version: '18.0.0', module: './index.mjs' })
+      );
+
+  it('resolves each key to the installed version of its package root', () => {
+    const repo = createPackageJsonRepository(versionsIo());
+
+    expect(installedVersions(['@scope/lib', '@scope/lib/testing', 'react'], WS, repo)).toEqual({
+      '@scope/lib': '2.5.0',
+      '@scope/lib/testing': '2.5.0',
+      react: '18.0.0',
+    });
+  });
+
+  it('agrees with the version PackageInfo records, which is what the cache metadata stores', () => {
+    const repo = createPackageJsonRepository(versionsIo());
+
+    expect(installedVersions(['@scope/lib'], WS, repo)['@scope/lib']).toBe(
+      tryGetPackageInfo('@scope/lib', WS, repo)?.version
+    );
+  });
+
+  it('maps an unresolvable package to an empty string', () => {
+    const repo = createPackageJsonRepository(versionsIo());
+
+    expect(installedVersions(['not-installed'], WS, repo)).toEqual({ 'not-installed': '' });
+  });
+
+  it('maps a package.json without a version to an empty string', () => {
+    const io = versionsIo().setFile(
+      path.join(WS, 'node_modules/no-version/package.json'),
+      JSON.stringify({ module: './index.mjs' })
+    );
+
+    expect(installedVersions(['no-version'], WS, createPackageJsonRepository(io))).toEqual({
+      'no-version': '',
+    });
+  });
+
+  it('resolves once per package root, not once per key', () => {
+    const base = createPackageJsonRepository(versionsIo());
+    const findDep = vi.fn(base.findDepPackageJson);
+    const repo = { ...base, findDepPackageJson: findDep };
+
+    installedVersions(
+      ['@scope/lib', '@scope/lib/testing', '@scope/lib/rxjs-interop', 'react'],
+      WS,
+      repo
+    );
+
+    expect(findDep).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/utils/package/package-info.ts
+++ b/src/lib/utils/package/package-info.ts
@@ -1,6 +1,6 @@
 import { logger } from '../logger.js';
 import { normalize } from '../normalize.js';
-import { sharedPackageJsonRepository } from '../io/package-json-repository.js';
+import { getPkgFolder, sharedPackageJsonRepository } from '../io/package-json-repository.js';
 import type {
   PackageInfo,
   PackageJsonRepository,
@@ -55,6 +55,37 @@ export function getPackageInfo(
   }
 
   return info;
+}
+
+/**
+ * Installed version per key, from each key's package root. Resolution is deduped by root:
+ * `findDepPackageJson` trims to the root anyway, and that root package.json is also where
+ * `resolvePackageInfo` reads the `version` it records as `PackageInfo.version`, so a secondary
+ * yields the same string as its main entry point. Unresolvable keys map to ''.
+ */
+export function installedVersions(
+  packageNames: string[],
+  workspaceRoot: string,
+  repo: PackageJsonRepository = sharedPackageJsonRepository
+): Record<string, string> {
+  workspaceRoot = normalize(workspaceRoot, true);
+
+  const byRoot = new Map<string, string>();
+  const result: Record<string, string> = {};
+
+  for (const packageName of packageNames) {
+    const root = getPkgFolder(packageName);
+
+    if (!byRoot.has(root)) {
+      const pkgJsonPath = repo.findDepPackageJson(root, workspaceRoot);
+      const version = pkgJsonPath ? (repo.readJson(pkgJsonPath)['version'] as string) : '';
+      byRoot.set(root, version ?? '');
+    }
+
+    result[packageName] = byRoot.get(root)!;
+  }
+
+  return result;
 }
 
 export function getVersionMaps(


### PR DESCRIPTION
Closes #103.

## The problem

The externals cache key's only version input was `shared[].version`, which holds the *declared*
range and is never set at all on the `shareAll` / `fromPackageJson` path — the default. Upgrading a
dependency therefore left the checksum unchanged, and the build copied a stale external into `dist`
while the app was compiled against the new version.

## The change

- **`installedVersions`** (`package-info.ts`) — resolves each key's installed version, deduped by
  package root. `findDepPackageJson` already trims to the root, and that root's package.json is
  where `resolvePackageInfo` reads the version it records as `PackageInfo.version`, so this returns
  exactly the string the cache metadata already stores.
- **`getChecksumCore`** takes those versions as a trailing optional argument and hashes them as
  their own `~<version>` component, separate from the declared `@<version>`. Omitting it is a
  byte-for-byte no-op, which the existing pinned-hash test proves. `getChecksum` is re-exported
  from `src/internal.ts`, so the parameter is optional and last — out-of-tree adapters are
  unaffected.
- **`bundle-shared.ts`** supplies them, preferring a configured `packageInfo.version` so the key
  follows the same source the build does.
- **`copyFiles`** now throws when a file recorded in the metadata is missing from the cache,
  instead of silently producing an incomplete `dist`.

Note that populating `shared[].version` on the `shareAll` path would *not* have fixed this — the
only value available there is the declared range.

## Verification

Unit tests: 397 passing. The `bundle-shared` test for the bug was checked against the unpatched
code and fails there (`expected [] to have a length of 1`), so it isn't vacuous.

Real app (`angular-examples/angular/simple`, mfe1 with `cacheExternalArtifacts: true`), bumping the
installed version of `@angular/common` without touching the app's package.json:

| build | cached bundles |
|---|---|
| published 4.3.2, after the bump | all 7, including `browser-angular_common` — the bug |
| this branch, nothing changed | all 7 — caching still works |
| this branch, after the bump | 6; `browser-angular_common` purged and rebuilt |

Invalidation is scoped to the bundle containing the changed package; the other six stay cached.

## Notes

- Existing caches invalidate once on upgrade — a single extra rebuild.
- Added cost is one `findDepPackageJson` + `readJson` per distinct package root per build; no
  entry-point resolution.
- The `AGENTS.md` docs commit corrects the caching section, which gave the cache location as
  `node_modules/.federation` (a path that appears nowhere in the source) and attributed
  `cache-persistence.ts` behaviour to `federation-cache.ts`.
