### PR TITLE
fix: Drop replayed watch events before they reach the dirty buffer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,16 +181,45 @@ explicitly keep their recursive watch and deliver every entry.
 
 ### Replay dedupe
 
-Events whose mtime is unchanged since the last one seen for that path are dropped before
-they reach either channel (`dedupeReplays`, default **on**). macOS FSEvents re-delivers
-'changed' for recently edited files roughly every 30s; with a watch list of a few thousand
-sources that replay alone keeps a rebuild loop awake forever.
+Events whose recorded identity — mtime **and** byte length — is unchanged since the last one
+seen for that path are dropped before they reach either channel (`dedupeReplays`, default
+**on**). macOS FSEvents re-delivers 'changed' for recently edited files roughly every 30s;
+with a watch list of a few thousand sources that replay alone keeps a rebuild loop awake
+forever.
 
-An unchanged-mtime event still passes inside `replayGraceMs` (default 2000) of the recorded
-mtime. That window is load-bearing, not cosmetic: it covers a second save inside one mtime
-tick (1s granularity on gRPC-FUSE/NFS/WSL2 drvfs) and an edit landing between the build
-finishing and `addPaths` seeding the already-new mtime. Dropping a real edit is the very
-bug the dedupe exists to prevent, so the check errs toward delivering.
+Length is paired with mtime so that the common ambiguous case — a second save landing inside
+one mtime tick, on a filesystem with coarse mtime granularity — is settled on data rather
+than on a clock. Only a save that also left byte length untouched reaches the time check.
+
+That check is `replayGraceMs` (default 2000): an event whose identity matches still passes
+while the mtime is recent. The default is a derived bound, not a tuned constant. A filesystem
+truncating mtime to granularity `g` records a value up to `g` before the write, so two writes
+can only collide in mtime within `2g` — and `g` is 1s on the coarsest filesystems in play
+(gRPC-FUSE, NFS, WSL2 drvfs, HFS+). On ext4 and APFS `g` is nanoseconds, so a real save always
+advances mtime and the window is never reached.
+
+Age is measured from when the event *arrived*, not from when a debounced flush got round to
+it, so `debounceMs` is not silently subtracted from the window. Two limits are worth knowing:
+a stall inside the event loop delays the `fs.watch` callback itself, which no local bookkeeping
+can correct; and on a network mount the age is a cross-clock subtraction, since mtime carries
+the server's clock. A server clock running ahead yields a negative age, which reads as recent
+and delivers — the safe direction. Running behind shortens the window, and there the only
+remedy is a larger `replayGraceMs` or `dedupeReplays: false`.
+
+Dropping a real edit is the bug the dedupe exists to prevent, so every ambiguous case errs
+toward delivering; a spurious rebuild is the cheaper mistake.
+
+### Watch failures are visible
+
+A watch that fails to open is silent staleness — the paths it covered never report a change
+and the dev server serves the last bundle until restart. Because watches are per directory,
+one failure can take a whole directory of sources down, so the first is a `logger.warn`.
+Later ones drop to debug: descriptor exhaustion fails every subsequent directory too, and a
+line per path would flood.
+
+Not covered by any of this: events the platform itself drops (inotify `IN_Q_OVERFLOW` under
+`git checkout` or `npm install` churn). Recovering those needs a reconciliation sweep that
+re-stats the tracked set — deliberately out of scope here, own issue.
 
 ## Caching System
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,38 @@ The library supports **watch mode** for development:
 
 - `src/lib/domain/core/build-notification-options.contract.ts` - Contract for notifications
 - `src/lib/core/rebuild-for-federation.ts` - Incremental rebuild logic
+- `src/lib/utils/file-watcher.ts` - `createNfWatcher` / `syncNfFileWatcher`
+
+### The watcher (`createNfWatcher`)
+
+An `fs.watch`-based watcher adapters can use to drive their rebuild loop. It has **two
+channels, both always live**:
+
+- **push** — the `onChange` callback, for waking a rebuild loop
+- **pull** — `get()` / `clear()` / `mutate()`, for reading _which_ files changed
+
+A listener-only consumer must still call `clear()`, or the dirty set grows for the process
+lifetime.
+
+`syncNfFileWatcher(watcher, sources, linkedDirs)` subscribes to the inputs of the last build.
+`sources` is either the input paths themselves or a bundler cache **keyed by input path**;
+a cache that records its inputs elsewhere yields an empty watch set and, silently, a dev
+server serving stale bundles until restart (angular-adapter#94). `linkedDirs` (from
+`linkedSharedDirs`) are polled rather than natively watched, because ng-packagr's atomic
+dist rewrites change the inode and defeat `fs.watch`.
+
+### Replay dedupe
+
+Events whose mtime is unchanged since the last one seen for that path are dropped before
+they reach either channel (`dedupeReplays`, default **on**). macOS FSEvents re-delivers
+'changed' for recently edited files roughly every 30s; with a watch list of a few thousand
+sources that replay alone keeps a rebuild loop awake forever.
+
+An unchanged-mtime event still passes inside `replayGraceMs` (default 2000) of the recorded
+mtime. That window is load-bearing, not cosmetic: it covers a second save inside one mtime
+tick (1s granularity on gRPC-FUSE/NFS/WSL2 drvfs) and an edit landing between the build
+finishing and `addPaths` seeding the already-new mtime. Dropping a real edit is the very
+bug the dedupe exists to prevent, so the check errs toward delivering.
 
 ## Caching System
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,12 +155,29 @@ channels, both always live**:
 A listener-only consumer must still call `clear()`, or the dirty set grows for the process
 lifetime.
 
+### What to watch
+
 `syncNfFileWatcher(watcher, sources, linkedDirs)` subscribes to the inputs of the last build.
 `sources` is either the input paths themselves or a bundler cache **keyed by input path**;
 a cache that records its inputs elsewhere yields an empty watch set and, silently, a dev
 server serving stale bundles until restart (angular-adapter#94). `linkedDirs` (from
 `linkedSharedDirs`) are polled rather than natively watched, because ng-packagr's atomic
 dist rewrites change the inode and defeat `fs.watch`.
+
+`sharedMappingDirs(config)` is the config-only alternative: the source dir of every
+`sharedMappings` entry point. It is coarser than a build's compiled inputs and covers what
+they cannot — files added to a lib since the last build — but it does not follow imports out
+of the lib. An adapter that can enumerate its build inputs should watch both.
+
+### File watches go through the directory
+
+`addPaths` never opens a handle on a file. A per-file `fs.watch` holds an inode, and an editor
+that saves by rename-replace (JetBrains "safe write", vim `backupcopy=no`) replaces it — the
+handle then reports nothing, so the second save onward is silently lost. Each tracked file is
+covered by a non-recursive watch on its containing directory instead, filtered back down to the
+tracked set so the event surface is unchanged. This also collapses thousands of sources onto a
+few hundred handles, and reports files created after they were added. Directories passed
+explicitly keep their recursive watch and deliver every entry.
 
 ### Replay dedupe
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,14 @@ tracked set so the event surface is unchanged. This also collapses thousands of 
 few hundred handles, and reports files created after they were added. Directories passed
 explicitly keep their recursive watch and deliver every entry.
 
+One directory is one handle regardless of how many tracked files live in it or how the path is
+spelled, and a recursive watch supersedes the narrower watches it covers — so adding a file and
+later the directory containing it (the order `syncNfFileWatcher` itself uses, and the order an
+adapter watching both a mapping dir and its compiled inputs hits) delivers each save once, not
+twice. The one asymmetry is polling: a polled watch survives the inode replacement a native one
+misses, so it can stand in for a native watch over the same tree but never the reverse. A polled
+`linkedDirs` entry is therefore never superseded by a native parent.
+
 ### Replay dedupe
 
 Events whose recorded identity — mtime **and** byte length — is unchanged since the last one

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -39,7 +39,7 @@ export type {
   NfFileWatcherOptions,
 } from './lib/domain/utils/file-watcher.contract.js';
 export { syncNfFileWatcher, createNfWatcher, type WatchSources } from './lib/utils/file-watcher.js';
-export { linkedSharedDirs } from './lib/core/build/resolve-shared-dirs.js';
+export { linkedSharedDirs, sharedMappingDirs } from './lib/core/build/resolve-shared-dirs.js';
 // Correlates watcher paths with linkedSharedDirs output; both are posix, so consumers
 // must not hand-roll the prefix check with path.sep.
 export { isUnderDir, isUnderAnyDir } from './lib/utils/path-patterns.js';

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -38,7 +38,7 @@ export type {
   NfFileWatcher,
   NfFileWatcherOptions,
 } from './lib/domain/utils/file-watcher.contract.js';
-export { syncNfFileWatcher, createNfWatcher } from './lib/utils/file-watcher.js';
+export { syncNfFileWatcher, createNfWatcher, type WatchSources } from './lib/utils/file-watcher.js';
 export { linkedSharedDirs } from './lib/core/build/resolve-shared-dirs.js';
 // Correlates watcher paths with linkedSharedDirs output; both are posix, so consumers
 // must not hand-roll the prefix check with path.sep.

--- a/src/lib/core/build/resolve-shared-dirs.spec.ts
+++ b/src/lib/core/build/resolve-shared-dirs.spec.ts
@@ -4,6 +4,7 @@ import {
   linkedContentSignals,
   linkedSharedDirs,
   resolveSharedPackageDirs,
+  sharedMappingDirs,
 } from './resolve-shared-dirs.js';
 import { createMemoryIo } from '../../utils/io/__test-helpers__/memory-io.js';
 import type { NormalizedFederationConfig } from '../../domain/config/federation-config.contract.js';
@@ -51,7 +52,9 @@ describe('resolveSharedPackageDirs', () => {
     };
   }
 
-  const config = { shared: { '@scope/lib': {}, missing: {} } } as unknown as NormalizedFederationConfig;
+  const config = {
+    shared: { '@scope/lib': {}, missing: {} },
+  } as unknown as NormalizedFederationConfig;
   const fedOptions = { workspaceRoot: '/ws' } as NormalizedFederationOptions;
 
   it('maps each key to its realpath, following symlinks', () => {
@@ -98,6 +101,43 @@ describe('linkedSharedDirs', () => {
     });
 
     expect(linkedSharedDirs(cfg, fedOptions, io, repo)).toEqual(['/dev/lib']);
+  });
+});
+
+describe('sharedMappingDirs', () => {
+  const dirsFor = (sharedMappings: Record<string, string>): string[] =>
+    sharedMappingDirs({ sharedMappings } as unknown as NormalizedFederationConfig);
+
+  // getRawMappedPaths keys config.sharedMappings by the absolute entry-point file.
+  it('returns the source dir of each mapping entry point', () => {
+    expect(
+      dirsFor({
+        '/ws/libs/shell/src/index.ts': '@apex/shell',
+        '/ws/libs/ui/src/index.ts': '@apex/ui',
+      })
+    ).toEqual(['/ws/libs/shell/src', '/ws/libs/ui/src']);
+  });
+
+  it('dedupes libs that expose several entry points from one dir', () => {
+    expect(
+      dirsFor({
+        '/ws/libs/ui/src/index.ts': '@apex/ui',
+        '/ws/libs/ui/src/testing.ts': '@apex/ui/testing',
+      })
+    ).toEqual(['/ws/libs/ui/src']);
+  });
+
+  it('drops a mapping resolving into node_modules', () => {
+    expect(
+      dirsFor({
+        '/ws/node_modules/@apex/vendor/index.ts': '@apex/vendor',
+        '/ws/libs/ui/src/index.ts': '@apex/ui',
+      })
+    ).toEqual(['/ws/libs/ui/src']);
+  });
+
+  it('returns empty when nothing is mapped', () => {
+    expect(dirsFor({})).toEqual([]);
   });
 });
 

--- a/src/lib/core/build/resolve-shared-dirs.ts
+++ b/src/lib/core/build/resolve-shared-dirs.ts
@@ -61,6 +61,22 @@ export function linkedSharedDirs(
   return [...new Set(entries.filter(e => e.isSymlink).map(e => e.realDir))];
 }
 
+/**
+ * Source directories of the workspace libs in `config.sharedMappings` — the watch set
+ * for mappings, derived from config alone rather than from a bundler cache.
+ *
+ * Coarser than the inputs a build actually compiled, and deliberately so: it covers
+ * files added to a lib after the last build, which a compiled-inputs watch set cannot
+ * know about yet. It does not follow imports out of the lib, so an adapter that can
+ * enumerate its build inputs should watch both. See angular-adapter#94.
+ */
+export function sharedMappingDirs(config: NormalizedFederationConfig): string[] {
+  const dirs = Object.keys(config.sharedMappings)
+    .map(entryPoint => toPosix(path.dirname(entryPoint)))
+    .filter(dir => !dir.includes('node_modules'));
+  return [...new Set(dirs)];
+}
+
 function maxMtime(io: FileReaderPort, dir: string): number {
   let max = 0;
   const walk = (d: string) => {

--- a/src/lib/core/build/resolve-shared-dirs.ts
+++ b/src/lib/core/build/resolve-shared-dirs.ts
@@ -69,6 +69,12 @@ export function linkedSharedDirs(
  * files added to a lib after the last build, which a compiled-inputs watch set cannot
  * know about yet. It does not follow imports out of the lib, so an adapter that can
  * enumerate its build inputs should watch both. See angular-adapter#94.
+ *
+ * How coarse is the caller's to bound: an entry point that is not a lib barrel widens the
+ * watch to whatever directory it sits in (`'@app/env': ['src/environments/environment.ts']`
+ * to that folder, `'@shared': ['src/index.ts']` to all of `src`), and with `sharedMappings`
+ * unset every tsconfig path becomes a mapping. Watch these natively rather than polled —
+ * they are source trees, not the dist output `linkedSharedDirs` exists for.
  */
 export function sharedMappingDirs(config: NormalizedFederationConfig): string[] {
   const dirs = Object.keys(config.sharedMappings)

--- a/src/lib/domain/utils/file-watcher.contract.ts
+++ b/src/lib/domain/utils/file-watcher.contract.ts
@@ -2,6 +2,17 @@ export interface NfFileWatcherOptions {
   onChange?: (path: string) => void;
   pollIntervalMs?: number;
   debounceMs?: number;
+  /** Drop events whose mtime is unchanged since the last one seen for that path.
+   *  macOS FSEvents re-delivers 'changed' for recently edited files roughly every
+   *  30s; with a watch list of a few thousand sources that replay alone keeps a
+   *  rebuild loop awake forever. Default: true. */
+  dedupeReplays?: boolean;
+  /** Grace period after a path's recorded mtime during which an unchanged-mtime
+   *  event still passes. Guards two real-edit cases the equality check would
+   *  otherwise swallow: a second save inside one mtime tick (1s granularity on
+   *  gRPC-FUSE/NFS/WSL2 drvfs), and an edit landing between the build finishing
+   *  and addPaths recording the already-new mtime. Default: 2000. */
+  replayGraceMs?: number;
 }
 
 interface AddPathsOptions {

--- a/src/lib/domain/utils/file-watcher.contract.ts
+++ b/src/lib/domain/utils/file-watcher.contract.ts
@@ -7,11 +7,12 @@ export interface NfFileWatcherOptions {
    *  30s; with a watch list of a few thousand sources that replay alone keeps a
    *  rebuild loop awake forever. Default: true. */
   dedupeReplays?: boolean;
-  /** Grace period after a path's recorded mtime during which an unchanged-mtime
-   *  event still passes. Guards two real-edit cases the equality check would
-   *  otherwise swallow: a second save inside one mtime tick (1s granularity on
-   *  gRPC-FUSE/NFS/WSL2 drvfs), and an edit landing between the build finishing
-   *  and addPaths recording the already-new mtime. Default: 2000. */
+  /** Grace period after a path's recorded mtime during which an event whose mtime
+   *  and byte length both match still passes, covering a second save inside one
+   *  mtime tick. The 2000 default is twice the coarsest mtime granularity in play
+   *  (1s on gRPC-FUSE/NFS/WSL2 drvfs/HFS+); raise it for a filesystem coarser than
+   *  that, or for a network mount whose server clock runs behind the client.
+   *  See AGENTS.md "Replay dedupe". Default: 2000. */
   replayGraceMs?: number;
 }
 

--- a/src/lib/domain/utils/io-port.contract.ts
+++ b/src/lib/domain/utils/io-port.contract.ts
@@ -50,9 +50,9 @@ interface WatchOptions {
 
 export interface WatchPort {
   /**
-   * For a recursive directory watch `onEvent` receives the changed entry's
-   * filename relative to `path`; for a file it receives the path itself (or
-   * null when the platform omits it).
+   * `onEvent` receives the changed entry's filename relative to `path` (null when
+   * the platform omits it). Watching a file reports that file's own basename, so a
+   * caller that registered a file can ignore the argument.
    */
   watch(path: string, opts: WatchOptions, onEvent: (filename: string | null) => void): WatchHandle;
 }

--- a/src/lib/domain/utils/io-port.contract.ts
+++ b/src/lib/domain/utils/io-port.contract.ts
@@ -7,6 +7,8 @@ export interface Digest {
 
 export interface StatInfo {
   mtimeMs: number;
+  /** Byte length; 0 for directories. */
+  size: number;
   isSymbolicLink: boolean;
 }
 

--- a/src/lib/utils/file-watcher.spec.ts
+++ b/src/lib/utils/file-watcher.spec.ts
@@ -72,15 +72,23 @@ describe('createNfWatcherCore', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
-  it('logs (and swallows) when a path cannot be watched', () => {
+  // A directory watch that never opened takes every source under it down with it,
+  // so the first failure is a warning rather than a debug line. Subsequent ones
+  // drop back to debug: descriptor exhaustion fails every directory after the first.
+  it('warns once (and swallows) when a path cannot be watched', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
     const debug = vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
     const io = createMemoryIo();
     io.watch = () => {
       throw new Error('boom');
     };
 
-    expect(() => createNfWatcherCore(io, {}).addPaths('/nope')).not.toThrow();
-    expect(debug).toHaveBeenCalled();
+    const watcher = createNfWatcherCore(io, {});
+    expect(() => watcher.addPaths(['/a/one.ts', '/b/two.ts', '/c/three.ts'])).not.toThrow();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('/a');
+    expect(debug).toHaveBeenCalledTimes(2);
   });
 
   it('passes the poll option to io.watch for polled paths', () => {
@@ -297,6 +305,55 @@ describe('createNfWatcherCore replay dedupe', () => {
     watcher.clear();
     io.emit(dir, 'a.ts');
     expect(watcher.get().size).toBe(0);
+  });
+
+  // The clock is only consulted when mtime *and* length both match. A save that
+  // changed how much it wrote is settled without it, which is what keeps a wrong
+  // age (event-loop stall, server-clock skew) from swallowing the common case.
+  it('passes an aged same-mtime event whose length changed', () => {
+    const io = seeded();
+    const watcher = createNfWatcherCore(io, {}, clock);
+
+    watcher.addPaths(file);
+    io.setFile(file, 'export const a = 1;\n'); // mtime deliberately left at AGED
+    emitFile(io, file);
+
+    expect([...watcher.get()]).toEqual([posix(file)]);
+  });
+
+  // A network mount whose server clock runs ahead stamps mtimes in the future, so
+  // the age goes negative. That has to read as recent (deliver), not as aged: the
+  // dedupe going quiet costs a spurious rebuild, dropping the event costs an edit.
+  it('delivers when the mtime is in the future', () => {
+    const io = createMemoryIo()
+      .setFile(file, '')
+      .setMtime(file, NOW + 60_000);
+    const watcher = createNfWatcherCore(io, {}, clock);
+
+    watcher.addPaths(file);
+    emitFile(io, file);
+
+    expect([...watcher.get()]).toEqual([posix(file)]);
+  });
+
+  // Otherwise debounceMs is subtracted from the window: the event below has 100ms
+  // of grace left on arrival and none by the time the flush runs.
+  it('measures the grace window from event arrival, not from the debounced flush', () => {
+    vi.useFakeTimers();
+    let t = NOW;
+    const io = createMemoryIo()
+      .setFile(file, '')
+      .setMtime(file, NOW - 1900);
+    const onChange = vi.fn();
+    const watcher = createNfWatcherCore(io, { onChange, debounceMs: 300 }, () => t);
+
+    watcher.addPaths(file);
+    emitFile(io, file);
+    t = NOW + 300;
+    vi.advanceTimersByTime(300);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
   });
 
   it('delivers every event when dedupeReplays is off', () => {

--- a/src/lib/utils/file-watcher.spec.ts
+++ b/src/lib/utils/file-watcher.spec.ts
@@ -4,6 +4,14 @@ import { createNfWatcherCore, syncNfFileWatcher } from './file-watcher.js';
 import { createMemoryIo } from './io/__test-helpers__/memory-io.js';
 import { logger } from './logger.js';
 
+// A fixed clock keeps the replay grace window (2000ms after a path's mtime)
+// deterministic; memory-io reports mtime 0 unless setMtime says otherwise, which
+// would make every seeded file look ancient against a real Date.now().
+const NOW = 1_700_000_000_000;
+const clock = () => NOW;
+const AGED = NOW - 60_000; // well outside the grace window
+const posix = (p: string): string => path.resolve(p).replace(/\\/g, '/');
+
 describe('createNfWatcherCore', () => {
   it('accumulates changed paths in dirtyPaths when no onChange handler is given', () => {
     const dir = path.resolve('/proj/src');
@@ -20,28 +28,33 @@ describe('createNfWatcherCore', () => {
   // loop from onChange but reads *which* files changed from get()/clear().
   it('buffers into dirtyPaths and invokes onChange when a handler is provided', () => {
     const file = path.resolve('/proj/file.ts');
-    const io = createMemoryIo().setFile(file, '');
-    const posix = file.replace(/\\/g, '/');
+    const io = createMemoryIo().setFile(file, '').setMtime(file, AGED);
     const onChange = vi.fn();
-    const watcher = createNfWatcherCore(io, { onChange });
+    const watcher = createNfWatcherCore(io, { onChange }, clock);
 
     watcher.addPaths(file);
+    io.setMtime(file, NOW); // the save the event reports
     io.emit(file);
 
-    expect(onChange).toHaveBeenCalledWith(posix);
-    expect([...watcher.get()]).toEqual([posix]);
+    expect(onChange).toHaveBeenCalledWith(posix(file));
+    expect([...watcher.get()]).toEqual([posix(file)]);
   });
 
   it('has already recorded the path by the time onChange runs', () => {
     const file = path.resolve('/proj/file.ts');
-    const io = createMemoryIo().setFile(file, '');
+    const io = createMemoryIo().setFile(file, '').setMtime(file, AGED);
     const seen: string[][] = [];
-    const watcher = createNfWatcherCore(io, { onChange: () => seen.push([...watcher.get()]) });
+    const watcher = createNfWatcherCore(
+      io,
+      { onChange: () => seen.push([...watcher.get()]) },
+      clock
+    );
 
     watcher.addPaths(file);
+    io.setMtime(file, NOW);
     io.emit(file);
 
-    expect(seen).toEqual([[file.replace(/\\/g, '/')]]);
+    expect(seen).toEqual([[posix(file)]]);
   });
 
   it('does not register the same path twice', () => {
@@ -120,6 +133,114 @@ describe('createNfWatcherCore', () => {
   });
 });
 
+// macOS FSEvents re-delivers 'changed' for recently edited files roughly every 30s
+// with mtime untouched. Once the watch list covers every compiled source, that
+// replay alone keeps a rebuild loop awake forever (angular-adapter#96).
+describe('createNfWatcherCore replay dedupe', () => {
+  const file = path.resolve('/proj/file.ts');
+  const seeded = () => createMemoryIo().setFile(file, '').setMtime(file, AGED);
+
+  it('drops a replayed same-mtime event from both channels', () => {
+    const io = seeded();
+    const onChange = vi.fn();
+    const watcher = createNfWatcherCore(io, { onChange }, clock);
+
+    watcher.addPaths(file);
+    io.emit(file);
+    io.emit(file);
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(watcher.get().size).toBe(0);
+  });
+
+  // Both cases the equality check alone would swallow: a second save inside one
+  // mtime tick, and an edit landing between the build and addPaths' seed.
+  it('passes an unchanged-mtime event still inside the grace window', () => {
+    const io = createMemoryIo()
+      .setFile(file, '')
+      .setMtime(file, NOW - 500);
+    const watcher = createNfWatcherCore(io, {}, clock);
+
+    watcher.addPaths(file);
+    io.emit(file);
+
+    expect([...watcher.get()]).toEqual([posix(file)]);
+  });
+
+  it('passes once the mtime advances, then drops the replay of that event', () => {
+    const io = seeded();
+    const onChange = vi.fn();
+    const watcher = createNfWatcherCore(io, { onChange }, clock);
+
+    watcher.addPaths(file);
+    io.setMtime(file, NOW - 30_000);
+    io.emit(file);
+    io.emit(file);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes when the file has vanished', () => {
+    const io = seeded();
+    const watcher = createNfWatcherCore(io, {}, clock);
+
+    watcher.addPaths(file);
+    io.remove(file);
+    io.emit(file);
+
+    expect([...watcher.get()]).toEqual([posix(file)]);
+  });
+
+  // Entries of a watched directory are never seeded (that would mean walking the
+  // tree), so they seed themselves on the event that first reports them.
+  it('passes the first event for an unseeded file under a watched directory', () => {
+    const dir = path.resolve('/proj/src');
+    const entry = path.join(dir, 'a.ts');
+    const io = createMemoryIo().setDir(dir).setFile(entry, '').setMtime(entry, AGED);
+    const watcher = createNfWatcherCore(io, {}, clock);
+
+    watcher.addPaths(dir);
+    io.emit(dir, 'a.ts');
+    expect([...watcher.get()]).toEqual([posix(entry)]);
+
+    watcher.clear();
+    io.emit(dir, 'a.ts');
+    expect(watcher.get().size).toBe(0);
+  });
+
+  it('delivers every event when dedupeReplays is off', () => {
+    const io = seeded();
+    const onChange = vi.fn();
+    const watcher = createNfWatcherCore(io, { onChange, dedupeReplays: false }, clock);
+
+    watcher.addPaths(file);
+    io.emit(file);
+    io.emit(file);
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  // io.stat is lstat-based: without following the link, an edit to the target is
+  // invisible and every event for a symlinked source looks like a replay.
+  it('compares the target mtime for a symlinked file', () => {
+    const link = path.resolve('/proj/link.ts');
+    const target = path.resolve('/dev/lib/real.ts');
+    const io = createMemoryIo()
+      .setFile(target, '')
+      .setSymlink(link, target)
+      .setMtime(link, AGED)
+      .setMtime(target, AGED);
+    const watcher = createNfWatcherCore(io, {}, clock);
+
+    watcher.addPaths(link);
+    io.setMtime(target, NOW - 10_000); // target edited; the link's own mtime stands
+
+    io.emit(link);
+
+    expect([...watcher.get()]).toEqual([posix(link)]);
+  });
+});
+
 describe('syncNfFileWatcher', () => {
   it('adds non-node_modules cache keys to the watcher', () => {
     const added: string[] = [];
@@ -149,5 +270,41 @@ describe('syncNfFileWatcher', () => {
     );
 
     expect(added).toEqual(['/proj/a.ts', '/dev/lib/dist']);
+  });
+
+  describe('source shapes', () => {
+    const collect = (sources: Parameters<typeof syncNfFileWatcher>[1]): string[] => {
+      const added: string[] = [];
+      const watcher = {
+        addPaths: (p: string | readonly string[]) =>
+          added.push(...(typeof p === 'string' ? [p] : [...p])),
+      } as never;
+      syncNfFileWatcher(watcher, sources);
+      return added;
+    };
+
+    it('reads a Map keyed by input path', () => {
+      expect(collect(new Map([['/proj/a.ts', {}]]))).toEqual(['/proj/a.ts']);
+    });
+
+    // Arrays expose keys() too, but it yields indices — taking that branch would
+    // hand the watcher '0' and '1'.
+    it('reads an array of paths rather than its indices', () => {
+      expect(collect(['/proj/a.ts', '/proj/node_modules/x/index.js'])).toEqual(['/proj/a.ts']);
+    });
+
+    it('reads a Set of paths', () => {
+      expect(collect(new Set(['/proj/a.ts']))).toEqual(['/proj/a.ts']);
+    });
+
+    it('reads a bare iterable', () => {
+      expect(
+        collect(
+          (function* () {
+            yield '/proj/a.ts';
+          })()
+        )
+      ).toEqual(['/proj/a.ts']);
+    });
   });
 });

--- a/src/lib/utils/file-watcher.spec.ts
+++ b/src/lib/utils/file-watcher.spec.ts
@@ -89,6 +89,26 @@ describe('createNfWatcherCore', () => {
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0][0]).toContain('/a');
     expect(debug).toHaveBeenCalledTimes(2);
+    warn.mockRestore();
+    debug.mockRestore();
+  });
+
+  // close() reopens everything on the next add, so the visibility resets with it.
+  it('warns again on the first failure after close()', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+    const io = createMemoryIo();
+    io.watch = () => {
+      throw new Error('boom');
+    };
+
+    const watcher = createNfWatcherCore(io, {});
+    watcher.addPaths('/a/one.ts');
+    await watcher.close();
+    watcher.addPaths('/b/two.ts');
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    vi.restoreAllMocks();
   });
 
   it('passes the poll option to io.watch for polled paths', () => {
@@ -219,6 +239,53 @@ describe('createNfWatcherCore file watches', () => {
     );
   });
 
+  // syncNfFileWatcher adds the build's input files before its directories, and an
+  // adapter watching both a mapping dir and its compiled inputs hits the same order.
+  // Both watches would then report the same save.
+  it('supersedes a file watch when the directory covering it is added afterwards', () => {
+    const io = createMemoryIo().setDir(dir).setFile(a, '').setMtime(a, AGED);
+    const spy = vi.spyOn(io, 'watch');
+    const onChange = vi.fn();
+    const watcher = createNfWatcherCore(io, { onChange }, clock);
+
+    watcher.addPaths(a);
+    watcher.addPaths(dir);
+
+    io.setMtime(a, NOW);
+    emitFile(io, a);
+
+    expect(spy).toHaveBeenCalledTimes(2); // the file's dir, then the recursive dir
+    expect(onChange).toHaveBeenCalledTimes(1); // ...but only one live handle
+    expect([...watcher.get()]).toEqual([posix(a)]);
+  });
+
+  it('supersedes a narrower directory watch when a broader one is added', () => {
+    const nested = path.join(dir, 'nested');
+    const file = path.join(nested, 'other.ts');
+    const io = createMemoryIo().setDir(dir).setDir(nested).setFile(file, '').setMtime(file, AGED);
+    const onChange = vi.fn();
+    const watcher = createNfWatcherCore(io, { onChange }, clock);
+
+    watcher.addPaths([nested, dir]);
+
+    io.setMtime(file, NOW);
+    io.emit(nested, 'other.ts'); // the superseded handle is closed, so nothing here
+    expect(onChange).not.toHaveBeenCalled();
+
+    io.emit(dir, path.join('nested', 'other.ts'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect([...watcher.get()]).toEqual([posix(file)]);
+  });
+
+  it('treats the same directory spelled two ways as one watch', () => {
+    const io = createMemoryIo().setDir(dir);
+    const spy = vi.spyOn(io, 'watch');
+
+    createNfWatcherCore(io, {}, clock).addPaths([dir, dir + path.sep, dir + '/']);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
   it('close() stops the directory watches opened for files', async () => {
     const io = createMemoryIo().setFile(a, '').setMtime(a, AGED);
     const watcher = createNfWatcherCore(io, {}, clock);
@@ -229,6 +296,57 @@ describe('createNfWatcherCore file watches', () => {
     io.setMtime(a, NOW);
     io.emit(dir, 'a.ts');
     expect(watcher.get().size).toBe(0);
+  });
+});
+
+// linkedDirs are polled because ng-packagr's atomic dist rewrites change the inode and
+// defeat fs.watch, so a native watch must never stand in for a polled one -- only the
+// other way round.
+describe('createNfWatcherCore poll coverage', () => {
+  const parent = path.resolve('/dev/lib');
+  const dist = path.join(parent, 'dist');
+  const emitted = path.join(dist, 'index.mjs');
+  const io = () => createMemoryIo().setDir(parent).setDir(dist);
+
+  it('keeps a polled watch when a native directory covering it is added after', () => {
+    const memory = io();
+    const watcher = createNfWatcherCore(memory, {}, clock);
+
+    watcher.addPaths(dist, { poll: true });
+    watcher.addPaths(parent);
+
+    memory.emit(dist, 'index.mjs'); // polled handle still live
+    expect([...watcher.get()]).toEqual([posix(emitted)]);
+  });
+
+  it('still opens a polled watch when a native directory already covers it', () => {
+    const memory = io();
+    const spy = vi.spyOn(memory, 'watch');
+    const watcher = createNfWatcherCore(memory, { pollIntervalMs: 250 }, clock);
+
+    watcher.addPaths(parent);
+    watcher.addPaths(dist, { poll: true });
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith(
+      dist,
+      expect.objectContaining({ poll: { intervalMs: 250 } }),
+      expect.any(Function)
+    );
+  });
+
+  it('lets a polled directory supersede a native watch under it', () => {
+    const memory = io();
+    const watcher = createNfWatcherCore(memory, {}, clock);
+
+    watcher.addPaths(dist);
+    watcher.addPaths(parent, { poll: true });
+
+    memory.emit(dist, 'index.mjs'); // native handle closed
+    expect(watcher.get().size).toBe(0);
+
+    memory.emit(parent, path.join('dist', 'index.mjs'));
+    expect([...watcher.get()]).toEqual([posix(emitted)]);
   });
 });
 

--- a/src/lib/utils/file-watcher.spec.ts
+++ b/src/lib/utils/file-watcher.spec.ts
@@ -12,6 +12,11 @@ const clock = () => NOW;
 const AGED = NOW - 60_000; // well outside the grace window
 const posix = (p: string): string => path.resolve(p).replace(/\\/g, '/');
 
+// Tracked files are watched through their containing directory, so an event for one
+// arrives on that directory carrying the entry name.
+const emitFile = (io: ReturnType<typeof createMemoryIo>, file: string): void =>
+  io.emit(path.dirname(file), path.basename(file));
+
 describe('createNfWatcherCore', () => {
   it('accumulates changed paths in dirtyPaths when no onChange handler is given', () => {
     const dir = path.resolve('/proj/src');
@@ -34,7 +39,7 @@ describe('createNfWatcherCore', () => {
 
     watcher.addPaths(file);
     io.setMtime(file, NOW); // the save the event reports
-    io.emit(file);
+    emitFile(io, file);
 
     expect(onChange).toHaveBeenCalledWith(posix(file));
     expect([...watcher.get()]).toEqual([posix(file)]);
@@ -52,7 +57,7 @@ describe('createNfWatcherCore', () => {
 
     watcher.addPaths(file);
     io.setMtime(file, NOW);
-    io.emit(file);
+    emitFile(io, file);
 
     expect(seen).toEqual([[posix(file)]]);
   });
@@ -133,6 +138,92 @@ describe('createNfWatcherCore', () => {
   });
 });
 
+// A per-file fs.watch handle dies when an editor saves by rename-replace (JetBrains
+// "safe write", vim backupcopy=no): the inode it holds is gone and every later edit
+// goes unreported. Watching the containing directory survives that.
+describe('createNfWatcherCore file watches', () => {
+  const dir = path.resolve('/proj/src');
+  const a = path.join(dir, 'a.ts');
+  const b = path.join(dir, 'b.ts');
+
+  it('watches the containing directory rather than the file itself', () => {
+    const io = createMemoryIo().setFile(a, '');
+    const spy = vi.spyOn(io, 'watch');
+
+    createNfWatcherCore(io, {}, clock).addPaths(a);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      posix(dir),
+      expect.objectContaining({ recursive: false }),
+      expect.any(Function)
+    );
+  });
+
+  it('opens one watch for every tracked file sharing a directory', () => {
+    const io = createMemoryIo().setFile(a, '').setFile(b, '');
+    const spy = vi.spyOn(io, 'watch');
+
+    createNfWatcherCore(io, {}, clock).addPaths([a, b]);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  // The directory reports every entry, so the tracked set has to narrow it back
+  // down to the event surface per-file watching had.
+  it('ignores events for untracked neighbours in a watched directory', () => {
+    const io = createMemoryIo().setFile(a, '').setMtime(a, AGED).setFile(b, '');
+    const watcher = createNfWatcherCore(io, {}, clock);
+
+    watcher.addPaths(a);
+    io.emit(dir, 'b.ts');
+    expect(watcher.get().size).toBe(0);
+
+    io.setMtime(a, NOW);
+    io.emit(dir, 'a.ts');
+    expect([...watcher.get()]).toEqual([posix(a)]);
+  });
+
+  it('reports a file created after it was added', () => {
+    const io = createMemoryIo().setDir(dir);
+    const watcher = createNfWatcherCore(io, {}, clock);
+
+    watcher.addPaths(a); // does not exist yet — nothing to seed
+    io.setFile(a, '').setMtime(a, NOW);
+    io.emit(dir, 'a.ts');
+
+    expect([...watcher.get()]).toEqual([posix(a)]);
+  });
+
+  it('does not add a second watch when a recursive directory already covers the file', () => {
+    const io = createMemoryIo().setDir(dir).setFile(a, '');
+    const spy = vi.spyOn(io, 'watch');
+    const watcher = createNfWatcherCore(io, {}, clock);
+
+    watcher.addPaths(dir);
+    watcher.addPaths(a);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      dir,
+      expect.objectContaining({ recursive: true }),
+      expect.any(Function)
+    );
+  });
+
+  it('close() stops the directory watches opened for files', async () => {
+    const io = createMemoryIo().setFile(a, '').setMtime(a, AGED);
+    const watcher = createNfWatcherCore(io, {}, clock);
+
+    watcher.addPaths(a);
+    await watcher.close();
+
+    io.setMtime(a, NOW);
+    io.emit(dir, 'a.ts');
+    expect(watcher.get().size).toBe(0);
+  });
+});
+
 // macOS FSEvents re-delivers 'changed' for recently edited files roughly every 30s
 // with mtime untouched. Once the watch list covers every compiled source, that
 // replay alone keeps a rebuild loop awake forever (angular-adapter#96).
@@ -146,8 +237,8 @@ describe('createNfWatcherCore replay dedupe', () => {
     const watcher = createNfWatcherCore(io, { onChange }, clock);
 
     watcher.addPaths(file);
-    io.emit(file);
-    io.emit(file);
+    emitFile(io, file);
+    emitFile(io, file);
 
     expect(onChange).not.toHaveBeenCalled();
     expect(watcher.get().size).toBe(0);
@@ -162,7 +253,7 @@ describe('createNfWatcherCore replay dedupe', () => {
     const watcher = createNfWatcherCore(io, {}, clock);
 
     watcher.addPaths(file);
-    io.emit(file);
+    emitFile(io, file);
 
     expect([...watcher.get()]).toEqual([posix(file)]);
   });
@@ -174,8 +265,8 @@ describe('createNfWatcherCore replay dedupe', () => {
 
     watcher.addPaths(file);
     io.setMtime(file, NOW - 30_000);
-    io.emit(file);
-    io.emit(file);
+    emitFile(io, file);
+    emitFile(io, file);
 
     expect(onChange).toHaveBeenCalledTimes(1);
   });
@@ -186,7 +277,7 @@ describe('createNfWatcherCore replay dedupe', () => {
 
     watcher.addPaths(file);
     io.remove(file);
-    io.emit(file);
+    emitFile(io, file);
 
     expect([...watcher.get()]).toEqual([posix(file)]);
   });
@@ -214,8 +305,8 @@ describe('createNfWatcherCore replay dedupe', () => {
     const watcher = createNfWatcherCore(io, { onChange, dedupeReplays: false }, clock);
 
     watcher.addPaths(file);
-    io.emit(file);
-    io.emit(file);
+    emitFile(io, file);
+    emitFile(io, file);
 
     expect(onChange).toHaveBeenCalledTimes(2);
   });
@@ -235,7 +326,7 @@ describe('createNfWatcherCore replay dedupe', () => {
     watcher.addPaths(link);
     io.setMtime(target, NOW - 10_000); // target edited; the link's own mtime stands
 
-    io.emit(link);
+    emitFile(io, link);
 
     expect([...watcher.get()]).toEqual([posix(link)]);
   });

--- a/src/lib/utils/file-watcher.ts
+++ b/src/lib/utils/file-watcher.ts
@@ -1,9 +1,9 @@
-import { join } from 'path';
+import { dirname, join } from 'path';
 import type { WatchHandle, WatchPort, FileReaderPort } from '../domain/utils/io-port.contract.js';
 import type { NfFileWatcher, NfFileWatcherOptions } from '../domain/utils/file-watcher.contract.js';
 import { nodeIo } from './io/node-io-adapter.js';
 import { logger } from './logger.js';
-import { toPosix } from './path-patterns.js';
+import { isUnderAnyDir, toPosix } from './path-patterns.js';
 
 export function createNfWatcher(options: NfFileWatcherOptions = {}): NfFileWatcher {
   return createNfWatcherCore(nodeIo, options);
@@ -22,6 +22,15 @@ export function createNfWatcherCore(
   const watchers = new Map<string, WatchHandle>();
   const dirtyPaths = new Set<string>();
   const mtimes = new Map<string, number>();
+  // Files are watched through their containing directory rather than individually:
+  // a per-file handle dies when an editor saves by rename-replace (JetBrains' "safe
+  // write", vim backupcopy=no), after which every later edit goes unreported. The
+  // directory watch survives that, and collapses thousands of sources onto a few
+  // hundred handles. trackedFiles keeps the event surface identical to per-file
+  // watching -- untracked neighbours in the same directory are filtered out.
+  const trackedFiles = new Set<string>();
+  const fileDirWatchers = new Map<string, WatchHandle>();
+  const recursiveDirs: string[] = [];
 
   // io.stat is lstat-based, so a symlinked file reports the link's own mtime.
   // Follow it, as maxMtime does in resolve-shared-dirs.ts.
@@ -74,28 +83,46 @@ export function createNfWatcherCore(
       const list = typeof paths === 'string' ? [paths] : [...paths];
       const poll = opts?.poll ? { intervalMs: pollIntervalMs } : undefined;
       for (const p of list) {
-        if (watchers.has(p)) continue;
-        const isDir = io.isDirectory(p);
-        try {
-          const handle = isDir
-            ? io.watch(p, { recursive: true, poll }, filename => {
+        if (io.isDirectory(p)) {
+          if (watchers.has(p)) continue;
+          try {
+            watchers.set(
+              p,
+              io.watch(p, { recursive: true, poll }, filename => {
                 if (filename) notify(toPosix(join(p, filename)));
               })
-            : io.watch(p, { recursive: false, poll }, () => notify(toPosix(p)));
-          watchers.set(p, handle);
-        } catch {
-          logger.debug(`Could not watch path '${p}'.`);
+            );
+            recursiveDirs.push(toPosix(p));
+          } catch {
+            logger.debug(`Could not watch path '${p}'.`);
+          }
           continue;
         }
+
+        const key = toPosix(p);
+        if (trackedFiles.has(key)) continue;
+        trackedFiles.add(key);
         // Seed so the first replay after startup is already recognised as one.
-        // Directories are skipped: seeding a recursive watch means walking the tree,
-        // and their entries seed themselves on the event that first reports them.
-        if (dedupeReplays && !isDir) {
-          const key = toPosix(p);
-          if (!mtimes.has(key)) {
-            const mtime = mtimeOf(key);
-            if (mtime !== null) mtimes.set(key, mtime);
-          }
+        if (dedupeReplays && !mtimes.has(key)) {
+          const mtime = mtimeOf(key);
+          if (mtime !== null) mtimes.set(key, mtime);
+        }
+
+        // An explicitly watched directory already reports this file recursively.
+        if (isUnderAnyDir(key, recursiveDirs)) continue;
+        const dir = toPosix(dirname(p));
+        if (fileDirWatchers.has(dir)) continue;
+        try {
+          fileDirWatchers.set(
+            dir,
+            io.watch(dir, { recursive: false, poll }, filename => {
+              if (!filename) return;
+              const changed = toPosix(join(dir, filename));
+              if (trackedFiles.has(changed)) notify(changed);
+            })
+          );
+        } catch {
+          logger.debug(`Could not watch path '${dir}'.`);
         }
       }
     },
@@ -106,10 +133,14 @@ export function createNfWatcherCore(
 
     async close() {
       if (flushTimer) clearTimeout(flushTimer);
-      for (const handle of watchers.values()) {
+      for (const handle of [...watchers.values(), ...fileDirWatchers.values()]) {
         handle.close();
       }
       watchers.clear();
+      fileDirWatchers.clear();
+      // Both gate watch creation, so a re-add after close() has to reopen.
+      trackedFiles.clear();
+      recursiveDirs.length = 0;
     },
   };
 }

--- a/src/lib/utils/file-watcher.ts
+++ b/src/lib/utils/file-watcher.ts
@@ -21,42 +21,51 @@ export function createNfWatcherCore(
   const replayGraceMs = options.replayGraceMs ?? 2000;
   const watchers = new Map<string, WatchHandle>();
   const dirtyPaths = new Set<string>();
-  const mtimes = new Map<string, number>();
-  // Files are watched through their containing directory rather than individually:
-  // a per-file handle dies when an editor saves by rename-replace (JetBrains' "safe
-  // write", vim backupcopy=no), after which every later edit goes unreported. The
-  // directory watch survives that, and collapses thousands of sources onto a few
-  // hundred handles. trackedFiles keeps the event surface identical to per-file
-  // watching -- untracked neighbours in the same directory are filtered out.
+  const lastSeen = new Map<string, FileIdentity>();
+  // Files are watched through their containing directory, never individually;
+  // trackedFiles narrows the directory's events back down to them. See AGENTS.md
+  // "File watches go through the directory".
   const trackedFiles = new Set<string>();
   const fileDirWatchers = new Map<string, WatchHandle>();
   const recursiveDirs: string[] = [];
 
-  // io.stat is lstat-based, so a symlinked file reports the link's own mtime.
-  // Follow it, as maxMtime does in resolve-shared-dirs.ts.
-  const mtimeOf = (path: string): number | null => {
+  // io.stat is lstat-based, so a symlink reports its own mtime and length, not the
+  // target's. Follow it, as maxMtime does in resolve-shared-dirs.ts.
+  const identityOf = (path: string): FileIdentity | null => {
     let stat = io.stat(path);
     if (stat?.isSymbolicLink) stat = io.stat(io.realpath(path));
-    return stat?.mtimeMs ?? null;
+    return stat ? { mtimeMs: stat.mtimeMs, size: stat.size } : null;
   };
 
-  const isReplay = (path: string): boolean => {
-    const mtime = mtimeOf(path);
-    if (mtime === null) {
-      mtimes.delete(path); // deleted or renamed away — a rebuild must see it
+  // Identity first, clock only for what identity cannot settle; a negative age
+  // delivers. See AGENTS.md "Replay dedupe" for why 2000 is the default.
+  const isReplay = (path: string, at: number): boolean => {
+    const current = identityOf(path);
+    if (!current) {
+      lastSeen.delete(path); // deleted or renamed away — a rebuild must see it
       return false;
     }
-    if (mtimes.get(path) !== mtime) {
-      mtimes.set(path, mtime);
+    const previous = lastSeen.get(path);
+    lastSeen.set(path, current);
+    if (!previous || previous.mtimeMs !== current.mtimeMs || previous.size !== current.size) {
       return false;
     }
-    // Same mtime. Only a replay once it is old enough to rule out a second save
-    // inside one mtime tick and the addPaths seed race (see NfFileWatcherOptions).
-    return now() - mtime >= replayGraceMs;
+    return at - current.mtimeMs >= replayGraceMs;
   };
 
-  const deliver = (path: string) => {
-    if (dedupeReplays && isReplay(path)) return;
+  // Warn once, then fall back to debug: descriptor exhaustion fails every
+  // subsequent directory too. See AGENTS.md "Watch failures are visible".
+  let watchFailures = 0;
+  const watchFailed = (path: string) => {
+    if (++watchFailures > 1) return logger.debug(`Could not watch path '${path}'.`);
+    logger.warn(
+      `Could not watch '${path}'. Changes there will not trigger a rebuild; ` +
+        `run with verbose logging to see any further watch failures.`
+    );
+  };
+
+  const deliver = (path: string, at: number) => {
+    if (dedupeReplays && isReplay(path, at)) return;
     // Record before notifying: a listener may read get() synchronously and must
     // see itself.
     dirtyPaths.add(path);
@@ -64,15 +73,18 @@ export function createNfWatcherCore(
   };
 
   // Coalesce bursts (ng-packagr emits several writes per rebuild) into one flush.
-  const pending = new Set<string>();
+  // Each path keeps the time its first event arrived, so debounceMs is not
+  // subtracted from the replay grace window.
+  const pending = new Map<string, number>();
   let flushTimer: ReturnType<typeof setTimeout> | undefined;
   const flush = () => {
-    for (const p of pending) deliver(p);
+    for (const [p, at] of pending) deliver(p, at);
     pending.clear();
   };
   const notify = (path: string) => {
-    if (debounceMs <= 0) return deliver(path);
-    pending.add(path);
+    const at = now();
+    if (debounceMs <= 0) return deliver(path, at);
+    if (!pending.has(path)) pending.set(path, at);
     if (flushTimer) clearTimeout(flushTimer);
     flushTimer = setTimeout(flush, debounceMs);
     flushTimer.unref?.();
@@ -94,7 +106,7 @@ export function createNfWatcherCore(
             );
             recursiveDirs.push(toPosix(p));
           } catch {
-            logger.debug(`Could not watch path '${p}'.`);
+            watchFailed(p);
           }
           continue;
         }
@@ -103,9 +115,9 @@ export function createNfWatcherCore(
         if (trackedFiles.has(key)) continue;
         trackedFiles.add(key);
         // Seed so the first replay after startup is already recognised as one.
-        if (dedupeReplays && !mtimes.has(key)) {
-          const mtime = mtimeOf(key);
-          if (mtime !== null) mtimes.set(key, mtime);
+        if (dedupeReplays && !lastSeen.has(key)) {
+          const identity = identityOf(key);
+          if (identity) lastSeen.set(key, identity);
         }
 
         // An explicitly watched directory already reports this file recursively.
@@ -122,7 +134,7 @@ export function createNfWatcherCore(
             })
           );
         } catch {
-          logger.debug(`Could not watch path '${dir}'.`);
+          watchFailed(dir);
         }
       }
     },
@@ -138,11 +150,18 @@ export function createNfWatcherCore(
       }
       watchers.clear();
       fileDirWatchers.clear();
-      // Both gate watch creation, so a re-add after close() has to reopen.
+      // All three gate work in addPaths, so a re-add after close() has to redo it:
+      // reopen the watches, and re-seed rather than trust a stale identity.
       trackedFiles.clear();
       recursiveDirs.length = 0;
+      lastSeen.clear();
     },
   };
+}
+
+interface FileIdentity {
+  mtimeMs: number;
+  size: number;
 }
 
 /** A bundler cache keyed by input path, or the input paths themselves. */

--- a/src/lib/utils/file-watcher.ts
+++ b/src/lib/utils/file-watcher.ts
@@ -11,16 +11,45 @@ export function createNfWatcher(options: NfFileWatcherOptions = {}): NfFileWatch
 
 export function createNfWatcherCore(
   io: WatchPort & FileReaderPort,
-  options: NfFileWatcherOptions = {}
+  options: NfFileWatcherOptions = {},
+  now: () => number = Date.now
 ): NfFileWatcher {
   const { onChange } = options;
   const pollIntervalMs = options.pollIntervalMs ?? 300;
   const debounceMs = options.debounceMs ?? 0;
+  const dedupeReplays = options.dedupeReplays ?? true;
+  const replayGraceMs = options.replayGraceMs ?? 2000;
   const watchers = new Map<string, WatchHandle>();
   const dirtyPaths = new Set<string>();
+  const mtimes = new Map<string, number>();
+
+  // io.stat is lstat-based, so a symlinked file reports the link's own mtime.
+  // Follow it, as maxMtime does in resolve-shared-dirs.ts.
+  const mtimeOf = (path: string): number | null => {
+    let stat = io.stat(path);
+    if (stat?.isSymbolicLink) stat = io.stat(io.realpath(path));
+    return stat?.mtimeMs ?? null;
+  };
+
+  const isReplay = (path: string): boolean => {
+    const mtime = mtimeOf(path);
+    if (mtime === null) {
+      mtimes.delete(path); // deleted or renamed away — a rebuild must see it
+      return false;
+    }
+    if (mtimes.get(path) !== mtime) {
+      mtimes.set(path, mtime);
+      return false;
+    }
+    // Same mtime. Only a replay once it is old enough to rule out a second save
+    // inside one mtime tick and the addPaths seed race (see NfFileWatcherOptions).
+    return now() - mtime >= replayGraceMs;
+  };
 
   const deliver = (path: string) => {
-    // Record first: a listener may read get() synchronously and must see itself.
+    if (dedupeReplays && isReplay(path)) return;
+    // Record before notifying: a listener may read get() synchronously and must
+    // see itself.
     dirtyPaths.add(path);
     if (onChange) onChange(path);
   };
@@ -46,8 +75,9 @@ export function createNfWatcherCore(
       const poll = opts?.poll ? { intervalMs: pollIntervalMs } : undefined;
       for (const p of list) {
         if (watchers.has(p)) continue;
+        const isDir = io.isDirectory(p);
         try {
-          const handle = io.isDirectory(p)
+          const handle = isDir
             ? io.watch(p, { recursive: true, poll }, filename => {
                 if (filename) notify(toPosix(join(p, filename)));
               })
@@ -55,6 +85,17 @@ export function createNfWatcherCore(
           watchers.set(p, handle);
         } catch {
           logger.debug(`Could not watch path '${p}'.`);
+          continue;
+        }
+        // Seed so the first replay after startup is already recognised as one.
+        // Directories are skipped: seeding a recursive watch means walking the tree,
+        // and their entries seed themselves on the event that first reports them.
+        if (dedupeReplays && !isDir) {
+          const key = toPosix(p);
+          if (!mtimes.has(key)) {
+            const mtime = mtimeOf(key);
+            if (mtime !== null) mtimes.set(key, mtime);
+          }
         }
       }
     },
@@ -73,14 +114,34 @@ export function createNfWatcherCore(
   };
 }
 
+/** A bundler cache keyed by input path, or the input paths themselves. */
+export type WatchSources = Iterable<string> | { keys(): Iterable<string> };
+
+// Arrays expose keys() too, but it yields indices — rule one out before treating
+// a source as a cache.
+function toPaths(sources: WatchSources): Iterable<string> {
+  if (Array.isArray(sources)) return sources;
+  const cache = sources as { keys?: () => Iterable<string> };
+  return typeof cache.keys === 'function' ? cache.keys() : (sources as Iterable<string>);
+}
+
+/**
+ * Subscribe the watcher to the inputs the last build compiled.
+ *
+ * Passing a bundler cache only works when it is keyed by input path. A cache that
+ * records its inputs elsewhere yields an empty watch set and, silently, a dev server
+ * that serves stale bundles until restart — Angular's `SourceFileCache` extends `Map`
+ * but keeps its inputs in `typeScriptFileCache`/`referencedFiles`, which is
+ * angular-adapter#94. Adapters over such a cache must expand it and pass the paths.
+ */
 export function syncNfFileWatcher(
   watcher: NfFileWatcher,
-  bundlerCache: { keys(): IterableIterator<string> },
+  sources: WatchSources,
   // Realpath'd dirs of symlinked (npm-linked) shared packages — watched despite
   // living under node_modules. See core's `linkedSharedDirs`.
   linkedDirs: readonly string[] = []
 ): void {
-  const files = [...bundlerCache.keys()].filter(k => !k.includes('node_modules'));
+  const files = [...toPaths(sources)].filter(k => !k.includes('node_modules'));
   if (files.length) watcher.addPaths(files);
   if (linkedDirs.length) watcher.addPaths(linkedDirs, { poll: true });
 }

--- a/src/lib/utils/file-watcher.ts
+++ b/src/lib/utils/file-watcher.ts
@@ -3,7 +3,7 @@ import type { WatchHandle, WatchPort, FileReaderPort } from '../domain/utils/io-
 import type { NfFileWatcher, NfFileWatcherOptions } from '../domain/utils/file-watcher.contract.js';
 import { nodeIo } from './io/node-io-adapter.js';
 import { logger } from './logger.js';
-import { isUnderAnyDir, toPosix } from './path-patterns.js';
+import { isUnderDir, toPosix } from './path-patterns.js';
 
 export function createNfWatcher(options: NfFileWatcherOptions = {}): NfFileWatcher {
   return createNfWatcherCore(nodeIo, options);
@@ -19,15 +19,46 @@ export function createNfWatcherCore(
   const debounceMs = options.debounceMs ?? 0;
   const dedupeReplays = options.dedupeReplays ?? true;
   const replayGraceMs = options.replayGraceMs ?? 2000;
-  const watchers = new Map<string, WatchHandle>();
+  const watchers = new Map<string, DirWatch>();
   const dirtyPaths = new Set<string>();
   const lastSeen = new Map<string, FileIdentity>();
   // Files are watched through their containing directory, never individually;
   // trackedFiles narrows the directory's events back down to them. See AGENTS.md
   // "File watches go through the directory".
   const trackedFiles = new Set<string>();
-  const fileDirWatchers = new Map<string, WatchHandle>();
-  const recursiveDirs: string[] = [];
+  const fileDirWatchers = new Map<string, DirWatch>();
+
+  // One key per directory, so the same dir spelled two ways does not open a second
+  // handle. Both maps are keyed with it, and so are the coverage checks below.
+  const dirKey = (p: string): string => {
+    const posix = toPosix(p);
+    return posix.length > 1 ? posix.replace(/\/+$/, '') : posix;
+  };
+
+  // A polled watch survives the inode replacement a native one misses (the reason
+  // linkedDirs poll at all), so it can stand in for a native watch but never the
+  // other way round.
+  const covers = (path: string, poll: boolean): boolean => {
+    for (const [dir, watch] of watchers) {
+      if ((watch.poll || !poll) && isUnderDir(path, dir)) return true;
+    }
+    return false;
+  };
+
+  // A recursive watch reports every entry under it, so it supersedes the narrower
+  // watches it covers. Without this a file added before the directory containing it
+  // keeps its own watch and every save there reports twice.
+  const supersede = (dir: string, poll: boolean) => {
+    for (const map of [watchers, fileDirWatchers]) {
+      for (const [key, watch] of map) {
+        if (watch.poll && !poll) continue;
+        if (map === watchers && key === dir) continue;
+        if (!isUnderDir(key, dir)) continue;
+        watch.handle.close();
+        map.delete(key);
+      }
+    }
+  };
 
   // io.stat is lstat-based, so a symlink reports its own mtime and length, not the
   // target's. Follow it, as maxMtime does in resolve-shared-dirs.ts.
@@ -93,21 +124,24 @@ export function createNfWatcherCore(
   return {
     addPaths(paths, opts) {
       const list = typeof paths === 'string' ? [paths] : [...paths];
-      const poll = opts?.poll ? { intervalMs: pollIntervalMs } : undefined;
+      const shouldPoll = !!opts?.poll;
+      const poll = shouldPoll ? { intervalMs: pollIntervalMs } : undefined;
       for (const p of list) {
         if (io.isDirectory(p)) {
-          if (watchers.has(p)) continue;
+          const dir = dirKey(p);
+          if (watchers.has(dir) || covers(dir, shouldPoll)) continue;
           try {
-            watchers.set(
-              p,
-              io.watch(p, { recursive: true, poll }, filename => {
+            watchers.set(dir, {
+              handle: io.watch(p, { recursive: true, poll }, filename => {
                 if (filename) notify(toPosix(join(p, filename)));
-              })
-            );
-            recursiveDirs.push(toPosix(p));
+              }),
+              poll: shouldPoll,
+            });
           } catch {
             watchFailed(p);
+            continue;
           }
+          supersede(dir, shouldPoll);
           continue;
         }
 
@@ -121,18 +155,18 @@ export function createNfWatcherCore(
         }
 
         // An explicitly watched directory already reports this file recursively.
-        if (isUnderAnyDir(key, recursiveDirs)) continue;
-        const dir = toPosix(dirname(p));
+        if (covers(key, shouldPoll)) continue;
+        const dir = dirKey(dirname(p));
         if (fileDirWatchers.has(dir)) continue;
         try {
-          fileDirWatchers.set(
-            dir,
-            io.watch(dir, { recursive: false, poll }, filename => {
+          fileDirWatchers.set(dir, {
+            handle: io.watch(dir, { recursive: false, poll }, filename => {
               if (!filename) return;
               const changed = toPosix(join(dir, filename));
               if (trackedFiles.has(changed)) notify(changed);
-            })
-          );
+            }),
+            poll: shouldPoll,
+          });
         } catch {
           watchFailed(dir);
         }
@@ -145,16 +179,17 @@ export function createNfWatcherCore(
 
     async close() {
       if (flushTimer) clearTimeout(flushTimer);
-      for (const handle of [...watchers.values(), ...fileDirWatchers.values()]) {
+      for (const { handle } of [...watchers.values(), ...fileDirWatchers.values()]) {
         handle.close();
       }
       watchers.clear();
       fileDirWatchers.clear();
-      // All three gate work in addPaths, so a re-add after close() has to redo it:
-      // reopen the watches, and re-seed rather than trust a stale identity.
+      // Everything below gates work in addPaths, so a re-add after close() has to
+      // redo it: reopen the watches, re-seed rather than trust a stale identity, and
+      // warn again on the first failure.
       trackedFiles.clear();
-      recursiveDirs.length = 0;
       lastSeen.clear();
+      watchFailures = 0;
     },
   };
 }
@@ -162,6 +197,12 @@ export function createNfWatcherCore(
 interface FileIdentity {
   mtimeMs: number;
   size: number;
+}
+
+interface DirWatch {
+  handle: WatchHandle;
+  /** Polled rather than natively watched, so it also survives inode replacement. */
+  poll: boolean;
 }
 
 /** A bundler cache keyed by input path, or the input paths themselves. */

--- a/src/lib/utils/io/__test-helpers__/memory-io.ts
+++ b/src/lib/utils/io/__test-helpers__/memory-io.ts
@@ -123,7 +123,11 @@ export function createMemoryIo(): MemoryIo {
       const key = toKey(p);
       const isSymbolicLink = symlinks.has(key);
       if (!isSymbolicLink && !files.has(key) && !dirs.has(key)) return null;
-      return { mtimeMs: mtimes.get(key) ?? 0, isSymbolicLink };
+      return {
+        mtimeMs: mtimes.get(key) ?? 0,
+        size: files.get(key)?.byteLength ?? 0,
+        isSymbolicLink,
+      };
     },
     writeText(p, data) {
       const key = toKey(p);

--- a/src/lib/utils/io/__test-helpers__/memory-io.ts
+++ b/src/lib/utils/io/__test-helpers__/memory-io.ts
@@ -176,8 +176,12 @@ export function createMemoryIo(): MemoryIo {
       list.push(onEvent);
       watchers.set(key, list);
       return {
+        // Per listener, not per key: two handles can watch one path, and closing
+        // one must leave the other delivering as real fs.watch handles do.
         close: () => {
-          watchers.delete(key);
+          const remaining = (watchers.get(key) ?? []).filter(fn => fn !== onEvent);
+          if (remaining.length) watchers.set(key, remaining);
+          else watchers.delete(key);
         },
       };
     },

--- a/src/lib/utils/io/node-io-adapter.ts
+++ b/src/lib/utils/io/node-io-adapter.ts
@@ -85,11 +85,9 @@ export const nodeIo: IoPort = {
   },
   watch(watchPath, opts, onEvent): WatchHandle {
     if (opts.poll) return pollWatch(watchPath, opts.recursive, opts.poll.intervalMs, onEvent);
-    const watcher = opts.recursive
-      ? fs.watch(watchPath, { recursive: true }, (_event, filename) =>
-          onEvent(filename ? filename.toString() : null)
-        )
-      : fs.watch(watchPath, () => onEvent(watchPath));
+    const watcher = fs.watch(watchPath, { recursive: opts.recursive }, (_event, filename) =>
+      onEvent(filename ? filename.toString() : null)
+    );
     return { close: () => watcher.close() };
   },
 };

--- a/src/lib/utils/io/node-io-adapter.ts
+++ b/src/lib/utils/io/node-io-adapter.ts
@@ -51,7 +51,7 @@ export const nodeIo: IoPort = {
   stat(path): StatInfo | null {
     try {
       const s = fs.lstatSync(path);
-      return { mtimeMs: s.mtimeMs, isSymbolicLink: s.isSymbolicLink() };
+      return { mtimeMs: s.mtimeMs, size: s.size, isSymbolicLink: s.isSymbolicLink() };
     } catch {
       return null;
     }


### PR DESCRIPTION
Core-side counterpart to [angular-adapter#94](https://github.com/native-federation/angular-adapter/issues/94) / [angular-adapter#96](https://github.com/native-federation/angular-adapter/pull/96).

## Context

With the dev server running, edits to `sharedMappings` libraries and `exposes` sources never reached the emitted federation bundles. The adapter-side root cause is that `syncNfFileWatcher(watcher, bundlerCache)` was called with Angular's `SourceFileCache`, which extends `Map` but keeps its inputs in `typeScriptFileCache`/`referencedFiles` — so `keys()` was empty and the watch set never filled. That fix belongs in the adapter; it is Angular-private knowledge core cannot have.

But the adapter fix leans on core behaviour that does not hold, and its much wider watch list (~0 → ~1,900 paths) surfaces work that belongs in the watcher core owns.

## `onChange` could not veto the dirty buffer

`deliver()` records before notifying — deliberately, per fc87599, because the adapter needs both channels:

```ts
const deliver = (path: string) => {
  dirtyPaths.add(path);
  if (onChange) onChange(path);
};
```

So an adapter-side `onChange: p => { if (!isRealChange(p)) return; ... }` gates its rebuild loop but **cannot** keep the event out of the buffer. Downstream that meant replayed paths still became `modifiedFiles` for `rebuildForFederation`, bypassing the `modifiedFiles.length === 0` early-return in `rebuildAffectedExternals` and clearing shared-bundle cache entries for files that never changed — and any consumer gating on `watcher.get().size === 0` silently stopped working after the first replay.

The replay filter is generic (`fs.watch` behaviour, zero framework content), so it moves here, ahead of `dirtyPaths.add`.

## Changes

### Replay dedupe in the watcher

`dedupeReplays` (default on). Events whose recorded **identity** — mtime *and* byte length — is unchanged since the last one seen for that path are dropped before reaching either channel. macOS FSEvents re-delivers 'changed' for recently edited files roughly every 30s; with a watch list of a few thousand sources that replay alone keeps a rebuild loop awake indefinitely.

Length is paired with mtime so that the one genuinely ambiguous case — a second save landing inside a single mtime tick, on a filesystem with coarse granularity — is settled on **data** rather than on a clock. Only a save that also left byte length untouched reaches the time check at all, which is what keeps a wrong clock reading from swallowing the common case.

`replayGraceMs` (default 2000) is that time check: an identity-matching event still passes while the mtime is recent. **The default is a derived bound, not a tuned constant.** A filesystem truncating mtime to granularity `g` records a value up to `g` before the write, so two writes can only collide in mtime within `2g`; `g` is 1s on the coarsest filesystems in play (gRPC-FUSE, NFS, WSL2 drvfs, HFS+). On ext4 and APFS `g` is nanoseconds, so a real save always advances mtime and the window is never reached.

Age is measured from when the event **arrived**, not from when a debounced flush got round to it, so `debounceMs` is not silently subtracted from the window. Two limits are documented rather than papered over: an event-loop stall delays the `fs.watch` callback itself, which no local bookkeeping can correct; and on a network mount the age is a cross-clock subtraction, since mtime carries the server's clock. A server clock running **ahead** yields a negative age, which reads as recent and delivers — the safe direction, so it is left alone. Running **behind** shortens the window, and there the only remedy is a larger `replayGraceMs` or `dedupeReplays: false`.

`addPaths` seeds each newly watched **file's** identity so the first replay after startup is already recognised as one. Directories are skipped — seeding a recursive watch would mean walking the tree — and their entries seed themselves on the event that first reports them. `identityOf` follows one symlink level, mirroring `maxMtime` in `resolve-shared-dirs.ts`; `io.stat` is lstat-based, so without it every event for a symlinked source reads as a replay.

### File watches go through the directory

`addPaths` no longer opens a handle on a file. A per-file `fs.watch` holds an inode, and an editor that saves by rename-replace (JetBrains "safe write", vim `backupcopy=no`) replaces it — the handle then reports nothing, so the second save onward is silently lost. Each tracked file is covered by a non-recursive watch on its containing directory instead, filtered back down through `trackedFiles` so the event surface is unchanged. This also collapses thousands of sources onto a few hundred handles, and reports files created after they were added. Directories passed explicitly keep their recursive watch.

### A failed watch is no longer silent

Now that one watch covers a whole directory of sources, swallowing the throw at debug level hides exactly the #94 symptom: paths that never report a change and a dev server serving the last bundle until restart. The first failure is a `logger.warn` naming the path and the consequence. Later ones stay at debug — descriptor exhaustion fails every subsequent directory too, and a line per path would flood.

### `sharedMappingDirs`

The source dir of every `config.sharedMappings` entry point — a framework-agnostic watch set for mappings, derived from config alone rather than from a bundler cache. Coarser than a build's compiled inputs and deliberately so: it covers files added to a lib since the last build, which a compiled-inputs watch set cannot know about yet. It does not follow imports out of the lib, so an adapter that can enumerate its build inputs should watch both.

### `syncNfFileWatcher` accepts paths directly

The second parameter widens to `WatchSources = Iterable<string> | { keys(): Iterable<string> }`, so an adapter that has to expand its cache passes the resulting array instead of a synthetic `{ keys: () => files[Symbol.iterator]() }`. Backward compatible for cache-keyed-by-input-path consumers.

One trap worth knowing: **arrays expose `keys()` too**, and it yields indices — the `Array.isArray` check has to come first, and there is a test asserting real paths rather than `0, 1`.

The JSDoc now names the `SourceFileCache` case, so the next adapter author meets it as documentation rather than as a dev server serving stale bundles.

## Compatibility

`dedupeReplays` defaults to **on**, which is a behaviour change for existing consumers.

- [esbuild-adapter](https://github.com/native-federation/esbuild-adapter) uses a `Map<string, unknown>` keyed by input path, watched natively. On inotify a save always advances mtime, so the only events it loses are genuine no-ops. Set `dedupeReplays: false` to opt out.
- The `syncNfFileWatcher` signature change is additive — existing call sites keep working.
- `StatInfo` gains a required `size`. The io port is internal (not exported from `index.ts` or `internal.ts`), so this affects no consumer.
- Website docs (`adapters/build-your-own.md`, `core/api-reference.md`) stay accurate; they should gain a note about the dedupe, the widened parameter and `sharedMappingDirs` in a follow-up.

## Out of scope

- **Watcher pruning.** `watchers`, `fileDirWatchers`, `trackedFiles` and `lastSeen` are never pruned during a session, only cleared on `close()`. Linux inotify exhaustion is not a realistic blocker on modern distros (`max_user_watches` is 247k on the machine this was measured on), and directory collapsing cut handle count by roughly an order of magnitude, but the maps still grow monotonically. Own issue.
- **A reconciliation sweep.** Nothing here recovers events the platform itself dropped — inotify `IN_Q_OVERFLOW` under `git checkout` or `npm install` churn, where events are lost wholesale and `lastSeen` still holds the pre-checkout identity. Re-stat'ing the tracked set would catch every one and costs ~3.6 ms for 1,900 files (measured), but it needs a call-cadence decision: `addPaths` already runs once per build and needs no new API, yet delivering from there fires `onChange` inside the adapter's own post-build sync call and invites re-entrant rebuilds. Own issue — and note there that the motivation is queue overflow, **not** the dedupe. It cannot recover a wrongly-dropped ambiguous event, because in that case the recorded identity already equals the current one.

## Verification

`pnpm test` (440 tests / 44 files), `pnpm typecheck`, `pnpm lint` (0 errors; 5 warnings, all pre-existing `no-console` in `logger.ts`), `pnpm build`, `pnpm knip` all pass.

`file-watcher.spec.ts` goes from 10 to 30 tests. Two existing tests needed a fixed clock plus an mtime advance to model a real save. New coverage: replay dropped from both channels; an identity-matching event inside the grace window passing; an aged same-mtime event whose **length** changed passing; a future mtime delivering; the grace window measured from event arrival rather than from the debounced flush; mtime advance re-arming; vanished file passing; first event for an unseeded directory entry passing; `dedupeReplays: false`; symlink target mtime; directory-not-file watch registration, neighbour filtering, post-add file creation, and no double watch under a recursive dir; warn-once on watch failure; and all four `WatchSources` shapes.

Still to do end-to-end, on a workspace where the issue reproduces: link `dist/` into an angular-adapter#96 checkout and confirm a `sharedMappings` `.ts` save reaches the emitted bundle in **one** rebuild, that an 80s idle window after it records zero further cycles, and that two saves inside one second both land.
