### PR TITLE
test: cover the build notification endpoint gate

### DIFF
--- a/src/lib/core/build/build-for-federation.spec.ts
+++ b/src/lib/core/build/build-for-federation.spec.ts
@@ -54,7 +54,10 @@ function makeConfig(denseExternals: boolean): NormalizedFederationConfig {
   };
 }
 
-function makeFedOptions(externals: SharedInfo[]): NormalizedFederationOptions {
+function makeFedOptions(
+  externals: SharedInfo[],
+  overrides: Partial<NormalizedFederationOptions> = {}
+): NormalizedFederationOptions {
   return {
     workspaceRoot: '/ws',
     outputPath: 'dist',
@@ -67,6 +70,7 @@ function makeFedOptions(externals: SharedInfo[]): NormalizedFederationOptions {
       bundlerCache: {},
       cachePath: '/cache',
     },
+    ...overrides,
   };
 }
 
@@ -118,5 +122,46 @@ describe('buildForFederation — denseExternals wiring', () => {
     expect(onArg.externals).toEqual(offArg.externals);
     expect(onArg.externals).toEqual(seededExternals());
     expect(onArg.externals.every(s => 'outFileName' in s && !('entries' in s))).toBe(true);
+  });
+});
+
+describe('buildForFederation — build notification endpoint', () => {
+  const endpoint = '/nf:build-notifications';
+
+  // Remotes advertise the endpoint through remoteEntry.json, so this gate is what
+  // decides whether a consuming browser opens an event stream at all.
+  async function buildWith(overrides: Partial<NormalizedFederationOptions>) {
+    const info = await buildForFederation(
+      makeConfig(false),
+      makeFedOptions(seededExternals(), overrides),
+      []
+    );
+    return info.buildNotificationsEndpoint;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('publishes the endpoint for an enabled dev build', async () => {
+    expect(await buildWith({ dev: true, buildNotifications: { enable: true, endpoint } })).toBe(
+      endpoint
+    );
+  });
+
+  it('withholds the endpoint from a production build', async () => {
+    expect(
+      await buildWith({ dev: false, buildNotifications: { enable: true, endpoint } })
+    ).toBeUndefined();
+  });
+
+  it('withholds the endpoint when notifications are disabled', async () => {
+    expect(
+      await buildWith({ dev: true, buildNotifications: { enable: false, endpoint } })
+    ).toBeUndefined();
+  });
+
+  it('withholds the endpoint when notifications are unconfigured', async () => {
+    expect(await buildWith({ dev: true })).toBeUndefined();
   });
 });

--- a/src/lib/core/build/rebuild-for-federation.spec.ts
+++ b/src/lib/core/build/rebuild-for-federation.spec.ts
@@ -40,7 +40,10 @@ function config(): NormalizedFederationConfig {
   } as unknown as NormalizedFederationConfig;
 }
 
-function fedOptions(externals: SharedInfo[]): NormalizedFederationOptions {
+function fedOptions(
+  externals: SharedInfo[],
+  overrides: Partial<NormalizedFederationOptions> = {}
+): NormalizedFederationOptions {
   return {
     workspaceRoot: '/ws',
     outputPath: 'dist',
@@ -50,6 +53,7 @@ function fedOptions(externals: SharedInfo[]): NormalizedFederationOptions {
     entryPoints: [],
     cacheExternalArtifacts: true,
     federationCache: { externals, bundlerCache: {}, cachePath: '/cache' },
+    ...overrides,
   } as NormalizedFederationOptions;
 }
 
@@ -60,9 +64,12 @@ describe('rebuildForFederation — affected-external re-bundling', () => {
     vi.mocked(affectedSharedKeys).mockReturnValue(new Set(['a']));
     const stale: SharedInfo[] = [{ packageName: 'a', outFileName: 'a.stale.js' } as SharedInfo];
 
-    const info = await rebuildForFederation(config(), fedOptions(stale), ['a'], [
-      '/dev/lib/dist/src/a.ts',
-    ]);
+    const info = await rebuildForFederation(
+      config(),
+      fedOptions(stale),
+      ['a'],
+      ['/dev/lib/dist/src/a.ts']
+    );
 
     expect(executeSharedBundlePlans).toHaveBeenCalledOnce();
     expect(info.shared).toEqual([{ packageName: 'a', outFileName: 'a.fresh.js' }]);
@@ -72,9 +79,12 @@ describe('rebuildForFederation — affected-external re-bundling', () => {
     vi.mocked(affectedSharedKeys).mockReturnValue(new Set());
     const cached: SharedInfo[] = [{ packageName: 'a', outFileName: 'a.cached.js' } as SharedInfo];
 
-    const info = await rebuildForFederation(config(), fedOptions(cached), ['a'], [
-      '/unrelated/x.ts',
-    ]);
+    const info = await rebuildForFederation(
+      config(),
+      fedOptions(cached),
+      ['a'],
+      ['/unrelated/x.ts']
+    );
 
     expect(executeSharedBundlePlans).not.toHaveBeenCalled();
     expect(info.shared).toEqual(cached);
@@ -87,5 +97,41 @@ describe('rebuildForFederation — affected-external re-bundling', () => {
 
     expect(affectedSharedKeys).not.toHaveBeenCalled();
     expect(executeSharedBundlePlans).not.toHaveBeenCalled();
+  });
+});
+
+describe('rebuildForFederation — build notification endpoint', () => {
+  const endpoint = '/nf:build-notifications';
+
+  // A rebuild rewrites remoteEntry.json, so it has to reach the same verdict as the
+  // initial build or a watch would publish or retract the endpoint behind the app's back.
+  async function rebuildWith(overrides: Partial<NormalizedFederationOptions>) {
+    const cached: SharedInfo[] = [{ packageName: 'a', outFileName: 'a.cached.js' } as SharedInfo];
+    const info = await rebuildForFederation(config(), fedOptions(cached, overrides), ['a'], []);
+    return info.buildNotificationsEndpoint;
+  }
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('publishes the endpoint for an enabled dev rebuild', async () => {
+    expect(await rebuildWith({ dev: true, buildNotifications: { enable: true, endpoint } })).toBe(
+      endpoint
+    );
+  });
+
+  it('withholds the endpoint from a production rebuild', async () => {
+    expect(
+      await rebuildWith({ dev: false, buildNotifications: { enable: true, endpoint } })
+    ).toBeUndefined();
+  });
+
+  it('withholds the endpoint when notifications are disabled', async () => {
+    expect(
+      await rebuildWith({ dev: true, buildNotifications: { enable: false, endpoint } })
+    ).toBeUndefined();
+  });
+
+  it('withholds the endpoint when notifications are unconfigured', async () => {
+    expect(await rebuildWith({ dev: true })).toBeUndefined();
   });
 });


### PR DESCRIPTION
Whether a remote advertises `buildNotificationsEndpoint` in remoteEntry.json decides if a consuming browser opens an event stream at all. The `enable && dev` gate deciding it was untested.

`build-for-federation` and `rebuild-for-federation` each carry the condition separately, so a watch could publish or retract the endpoint without the initial build agreeing. Both are now covered.

Tests only.

Refs native-federation/native-federation-core#50
