### PR TITLE
fix: Spell the workspace root the way disk spells it

### DIFF
--- a/src/lib/config/configuration-context.spec.ts
+++ b/src/lib/config/configuration-context.spec.ts
@@ -1,9 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import {
-  getConfigContext,
-  usePackageJson,
-  useWorkspace,
-} from './configuration-context.js';
+import * as path from 'path';
+import { getConfigContext, usePackageJson, useWorkspace } from './configuration-context.js';
+import { createMemoryIo } from '../utils/io/__test-helpers__/memory-io.js';
 
 describe('configuration-context', () => {
   // The context is module-level singleton state; reset it around each test.
@@ -35,6 +33,14 @@ describe('configuration-context', () => {
       workspaceRoot: '/ws/root',
       packageJson: '/ws/root/package.json',
     });
+  });
+
+  // Nx reports workspaceRoot with whatever drive-letter case the invoking shell used; the
+  // sharedMappings keys derive from cwd(). Storing the disk spelling keeps the two comparable.
+  it('stores the on-disk spelling of the workspace root', () => {
+    const io = createMemoryIo().setDiskCase('c:/ws', 'C:/ws');
+    useWorkspace('c:/ws', io);
+    expect(getConfigContext().workspaceRoot).toBe(path.normalize('C:/ws'));
   });
 
   it('overwrites a previously set value on a subsequent call', () => {

--- a/src/lib/config/configuration-context.ts
+++ b/src/lib/config/configuration-context.ts
@@ -1,3 +1,7 @@
+import { nodeIo } from '../utils/io/node-io-adapter.js';
+import { toDiskCase } from '../utils/disk-case.js';
+import type { FileReaderPort } from '../domain/utils/io-port.contract.js';
+
 export interface ConfigurationContext {
   workspaceRoot?: string;
   packageJson?: string;
@@ -5,8 +9,8 @@ export interface ConfigurationContext {
 
 let _context: ConfigurationContext = {};
 
-export function useWorkspace(workspaceRoot: string): void {
-  _context = { ..._context, workspaceRoot };
+export function useWorkspace(workspaceRoot: string, io: FileReaderPort = nodeIo): void {
+  _context = { ..._context, workspaceRoot: toDiskCase(io, workspaceRoot) };
 }
 
 export function usePackageJson(packageJson?: string): void {

--- a/src/lib/config/get-used-dependencies.spec.ts
+++ b/src/lib/config/get-used-dependencies.spec.ts
@@ -91,7 +91,7 @@ describe('getUsedDependenciesFactoryCore', () => {
   // on 'c:/ws' (from Nx). Every affected library is pruned and silently missing from
   // remoteEntry.json, so the walk reports what the pruned set alone cannot distinguish.
   describe('case-only mapping misses', () => {
-    const caseOnly = /land in a shared mapping only when case is ignored/;
+    const caseOnly = /match a shared mapping only when case is ignored/;
 
     afterEach(() => {
       vi.restoreAllMocks();

--- a/src/lib/config/get-used-dependencies.spec.ts
+++ b/src/lib/config/get-used-dependencies.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ProjectData } from '@softarc/sheriff-core';
 import {
   getUsedDependenciesFactoryCore,
@@ -7,6 +7,8 @@ import {
 import { isSharedMapping, matchMapping } from './match-mapping.js';
 import { createMemoryIo } from '../utils/io/__test-helpers__/memory-io.js';
 import { createPackageJsonRepository } from '../utils/io/package-json-repository.js';
+import { logger } from '../utils/logger.js';
+import * as path from 'path';
 
 describe('getUsedDependenciesFactoryCore', () => {
   // Build deps backed by memory-io: `projectData` is the canned sheriff output
@@ -83,6 +85,69 @@ describe('getUsedDependenciesFactoryCore', () => {
     });
 
     expect(used.internal).toEqual({ '/ws/libs/ui/button.ts': '@org/ui/button' });
+  });
+
+  // The reported failure mode: mapping keys spelled 'C:/ws/…' (from cwd) against imports built
+  // on 'c:/ws' (from Nx). Every affected library is pruned and silently missing from
+  // remoteEntry.json, so the walk reports what the pruned set alone cannot distinguish.
+  describe('case-only mapping misses', () => {
+    const caseOnly = /land in a shared mapping only when case is ignored/;
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    function runWith(sharedMappings: Record<string, string>, workspaceRoot = 'c:/ws') {
+      const deps = makeDeps({
+        'src/comp.ts': {
+          imports: ['libs/ui/button.ts'],
+          externalLibraries: [],
+          unresolvedImports: [],
+        },
+      } as unknown as ProjectData);
+
+      return getUsedDependenciesFactoryCore(deps, workspaceRoot)({
+        exposes: { './Comp': { file: 'src/comp.ts' } },
+        sharedMappings,
+      });
+    }
+
+    it('warns and prunes when the mapping key differs from the import by case alone', () => {
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+      const used = runWith({ 'C:/ws/libs/ui/*': '@org/ui/*' });
+
+      expect(used.internal).toEqual({});
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(caseOnly));
+    });
+
+    it('names one of the affected imports so the mismatch is visible', () => {
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+      runWith({ 'C:/ws/libs/ui/*': '@org/ui/*' });
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(path.join('c:/ws', 'libs/ui/button.ts'))
+      );
+    });
+
+    it('stays silent when the import genuinely reaches no mapping', () => {
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+      const used = runWith({ 'c:/ws/libs/unrelated/*': '@org/unrelated/*' });
+
+      expect(used.internal).toEqual({});
+      expect(warn).not.toHaveBeenCalledWith(expect.stringMatching(caseOnly));
+    });
+
+    it('stays silent when the mapping matches on the nose', () => {
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+      const used = runWith({ [path.join('c:/ws', 'libs/ui') + '/*']: '@org/ui/*' });
+
+      expect(Object.keys(used.internal)).toHaveLength(1);
+      expect(warn).not.toHaveBeenCalledWith(expect.stringMatching(caseOnly));
+    });
   });
 
   it('falls back to the provided entry points when no exposes are present', () => {

--- a/src/lib/config/get-used-dependencies.ts
+++ b/src/lib/config/get-used-dependencies.ts
@@ -151,17 +151,17 @@ function resolveUsedMappings(
 
 /**
  * Reaching a mapping only once case is ignored means this build's workspace root and the mapping
- * keys spell the same directory differently, so the libraries behind them are pruned as
- * unreachable and go missing from remoteEntry.json with nothing failing. Distinguishing that
- * from a project that legitimately reaches none of the workspace's mappings is the whole point
- * of testing the misses rather than the emptied set.
+ * keys spell the same directory differently -- see utils/disk-case.ts for the roots that get
+ * corrected. `removeUnusedDeps` reports the consequence (every mapping pruned); this names the
+ * cause, which the emptied set alone cannot distinguish from a project that legitimately reaches
+ * no workspace library.
  */
 function warnOnCaseOnlyMisses(misses: ReadonlySet<string>): void {
   if (misses.size === 0) return;
 
   logger.warn(
     `${misses.size} import(s) land in a shared mapping only when case is ignored, so they were ` +
-      `pruned as unreachable — e.g. '${[...misses][0]}'. The emitted remoteEntry.json will not ` +
+      `pruned as unreachable -- e.g. '${[...misses][0]}'. The emitted remoteEntry.json will not ` +
       'advertise those workspace libraries.'
   );
 }

--- a/src/lib/config/get-used-dependencies.ts
+++ b/src/lib/config/get-used-dependencies.ts
@@ -150,9 +150,8 @@ function resolveUsedMappings(
 }
 
 /**
- * `matchMapping`'s rule with both sides lower-cased. Diagnosis only -- it never decides whether a
- * mapping is used. Lower-casing the mapping set once keeps it cheap enough to run on every
- * unmatched import, which is what makes a *partial* mismatch visible.
+ * Diagnosis only: never decides whether a mapping is used. Lower-casing the set once keeps it
+ * cheap enough for every unmatched import, which is what makes a partial mismatch visible.
  */
 function createCaseInsensitiveMatcher(
   sharedMappings: PathToImport
@@ -168,11 +167,9 @@ function createCaseInsensitiveMatcher(
 }
 
 /**
- * A path and a mapping key that agree only once case is ignored spell the same directory
- * differently: either the workspace root (see utils/disk-case.ts) or a mis-cased tsconfig `paths`
- * value, which TypeScript resolves fine on a case-insensitive filesystem while silently dropping
- * that one library. `removeUnusedDeps` warns when *every* mapping is pruned; only a per-import
- * test sees the partial case.
+ * A case-only hit means one directory spelled two ways: the workspace root (see
+ * utils/disk-case.ts), or a mis-cased tsconfig `paths` value that TypeScript resolves anyway on a
+ * case-insensitive filesystem. `removeUnusedDeps` covers all-pruned; only this sees a partial one.
  */
 function warnOnCaseOnlyMisses(misses: ReadonlySet<string>): void {
   if (misses.size === 0) return;

--- a/src/lib/config/get-used-dependencies.ts
+++ b/src/lib/config/get-used-dependencies.ts
@@ -8,7 +8,7 @@ import { type FileReaderPort } from '../domain/utils/io-port.contract.js';
 import { type PathToImport } from '../domain/utils/mapped-path.contract.js';
 import { type UsedDependencies } from '../domain/utils/used-dependencies.contract.js';
 import { type ExposeEntry } from '../domain/config/federation-config.contract.js';
-import { createCaseInsensitiveMatcher, isSharedMapping, matchMapping } from './match-mapping.js';
+import { isSharedMapping, matchMapping } from './match-mapping.js';
 import { logger } from '../utils/logger.js';
 import * as path from 'path';
 
@@ -150,11 +150,29 @@ function resolveUsedMappings(
 }
 
 /**
- * Reaching a mapping only once case is ignored means this build's workspace root and the mapping
- * keys spell the same directory differently -- see utils/disk-case.ts for the roots that get
- * corrected. `removeUnusedDeps` reports the consequence (every mapping pruned); this names the
- * cause, which the emptied set alone cannot distinguish from a project that legitimately reaches
- * no workspace library.
+ * `matchMapping`'s rule with both sides lower-cased. Diagnosis only -- it never decides whether a
+ * mapping is used. Lower-casing the mapping set once keeps it cheap enough to run on every
+ * unmatched import, which is what makes a *partial* mismatch visible.
+ */
+function createCaseInsensitiveMatcher(
+  sharedMappings: PathToImport
+): (filePath: string) => boolean {
+  const lowerCased = Object.fromEntries(
+    Object.entries(sharedMappings).map(([sharedPath, sharedImport]) => [
+      sharedPath.toLowerCase(),
+      sharedImport,
+    ])
+  );
+
+  return filePath => matchMapping(filePath.toLowerCase(), lowerCased) !== null;
+}
+
+/**
+ * A path and a mapping key that agree only once case is ignored spell the same directory
+ * differently: either the workspace root (see utils/disk-case.ts) or a mis-cased tsconfig `paths`
+ * value, which TypeScript resolves fine on a case-insensitive filesystem while silently dropping
+ * that one library. `removeUnusedDeps` warns when *every* mapping is pruned; only a per-import
+ * test sees the partial case.
  */
 function warnOnCaseOnlyMisses(misses: ReadonlySet<string>): void {
   if (misses.size === 0) return;

--- a/src/lib/config/get-used-dependencies.ts
+++ b/src/lib/config/get-used-dependencies.ts
@@ -56,6 +56,8 @@ export function getUsedDependenciesFactoryCore(
       throw new Error(
         '[removeUnusedDeps] native-federation is missing an entryPoint! You can set it using the Federation options or by setting an exposed module in the Federation config file.'
       );
+    // Not disk-cased like the cwd() in project-paths: sheriff relativizes every path it returns
+    // against this root, so its spelling cancels before those paths are re-joined below.
     const fileInfos = Object.values(entryPoints ?? []).reduce(
       (acc, entryPoint) => ({
         ...acc,

--- a/src/lib/config/get-used-dependencies.ts
+++ b/src/lib/config/get-used-dependencies.ts
@@ -177,9 +177,8 @@ function warnOnCaseOnlyMisses(misses: ReadonlySet<string>): void {
   if (misses.size === 0) return;
 
   logger.warn(
-    `${misses.size} import(s) land in a shared mapping only when case is ignored, so they were ` +
-      `pruned as unreachable -- e.g. '${[...misses][0]}'. The emitted remoteEntry.json will not ` +
-      'advertise those workspace libraries.'
+    `${misses.size} import(s) match a shared mapping only when case is ignored, so those ` +
+      `libraries were pruned from remoteEntry.json -- e.g. '${[...misses][0]}'.`
   );
 }
 

--- a/src/lib/config/get-used-dependencies.ts
+++ b/src/lib/config/get-used-dependencies.ts
@@ -8,7 +8,8 @@ import { type FileReaderPort } from '../domain/utils/io-port.contract.js';
 import { type PathToImport } from '../domain/utils/mapped-path.contract.js';
 import { type UsedDependencies } from '../domain/utils/used-dependencies.contract.js';
 import { type ExposeEntry } from '../domain/config/federation-config.contract.js';
-import { isSharedMapping, matchMapping } from './match-mapping.js';
+import { createCaseInsensitiveMatcher, isSharedMapping, matchMapping } from './match-mapping.js';
+import { logger } from '../utils/logger.js';
 import * as path from 'path';
 
 type GetProjectData = (
@@ -123,6 +124,8 @@ function resolveUsedMappings(
   sharedMappings: PathToImport
 ): PathToImport {
   const usedMappings: PathToImport = {};
+  const matchesIgnoringCase = createCaseInsensitiveMatcher(sharedMappings);
+  const caseOnlyMisses = new Set<string>();
 
   for (const fileName of Object.keys(fileInfos)) {
     const fullFileName = path.join(workspaceRoot, fileName);
@@ -137,9 +140,29 @@ function resolveUsedMappings(
       const fullImport = path.join(workspaceRoot, imp);
       const match = matchMapping(fullImport, sharedMappings);
       if (match) usedMappings[fullImport] = match;
+      else if (matchesIgnoringCase(fullImport)) caseOnlyMisses.add(fullImport);
     }
   }
 
+  warnOnCaseOnlyMisses(caseOnlyMisses);
+
   return usedMappings;
+}
+
+/**
+ * Reaching a mapping only once case is ignored means this build's workspace root and the mapping
+ * keys spell the same directory differently, so the libraries behind them are pruned as
+ * unreachable and go missing from remoteEntry.json with nothing failing. Distinguishing that
+ * from a project that legitimately reaches none of the workspace's mappings is the whole point
+ * of testing the misses rather than the emptied set.
+ */
+function warnOnCaseOnlyMisses(misses: ReadonlySet<string>): void {
+  if (misses.size === 0) return;
+
+  logger.warn(
+    `${misses.size} import(s) land in a shared mapping only when case is ignored, so they were ` +
+      `pruned as unreachable — e.g. '${[...misses][0]}'. The emitted remoteEntry.json will not ` +
+      'advertise those workspace libraries.'
+  );
 }
 

--- a/src/lib/config/match-mapping.ts
+++ b/src/lib/config/match-mapping.ts
@@ -47,25 +47,6 @@ export function matchMapping(filePath: string, sharedMappings: PathToImport): st
 }
 
 /**
- * `matchMapping`'s rule again, with both sides lower-cased. A hit here after a miss above means
- * the mapping keys and the path being tested spell the same directory differently — see
- * utils/disk-case.ts. The mapping set is lower-cased once, so the probe stays cheap enough to
- * run on every unmatched import.
- */
-export function createCaseInsensitiveMatcher(
-  sharedMappings: PathToImport
-): (filePath: string) => boolean {
-  const lowerCased = Object.fromEntries(
-    Object.entries(sharedMappings).map(([sharedPath, sharedImport]) => [
-      sharedPath.toLowerCase(),
-      sharedImport,
-    ])
-  );
-
-  return filePath => matchMapping(filePath.toLowerCase(), lowerCased) !== null;
-}
-
-/**
  * Detect if it's a barrel file which is inferred by typescript
  */
 const INDEX_PATTERN = /\/index\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;

--- a/src/lib/config/match-mapping.ts
+++ b/src/lib/config/match-mapping.ts
@@ -47,6 +47,25 @@ export function matchMapping(filePath: string, sharedMappings: PathToImport): st
 }
 
 /**
+ * `matchMapping`'s rule again, with both sides lower-cased. A hit here after a miss above means
+ * the mapping keys and the path being tested spell the same directory differently — see
+ * utils/disk-case.ts. The mapping set is lower-cased once, so the probe stays cheap enough to
+ * run on every unmatched import.
+ */
+export function createCaseInsensitiveMatcher(
+  sharedMappings: PathToImport
+): (filePath: string) => boolean {
+  const lowerCased = Object.fromEntries(
+    Object.entries(sharedMappings).map(([sharedPath, sharedImport]) => [
+      sharedPath.toLowerCase(),
+      sharedImport,
+    ])
+  );
+
+  return filePath => matchMapping(filePath.toLowerCase(), lowerCased) !== null;
+}
+
+/**
  * Detect if it's a barrel file which is inferred by typescript
  */
 const INDEX_PATTERN = /\/index\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;

--- a/src/lib/config/project-paths.spec.ts
+++ b/src/lib/config/project-paths.spec.ts
@@ -24,4 +24,16 @@ describe('findRootTsConfigJsonCore', () => {
   it('throws when neither config is present', () => {
     expect(() => findRootTsConfigJsonCore(withPackageJson())).toThrow(/Neither a tsconfig/);
   });
+
+  // The mirror image of the Nx case bug: cwd() is the mis-cased side. The returned path
+  // seeds every sharedMappings key, so it has to agree with the workspace root.
+  it('returns the on-disk spelling when cwd() is mis-cased', () => {
+    const disk = path.join(path.dirname(ROOT), path.basename(ROOT).toUpperCase());
+    const io = createMemoryIo()
+      .setDiskCase(ROOT, disk)
+      .setFile(path.join(disk, 'package.json'), '{}')
+      .setFile(path.join(disk, 'tsconfig.base.json'), '{}');
+
+    expect(findRootTsConfigJsonCore(io)).toBe(path.join(disk, 'tsconfig.base.json'));
+  });
 });

--- a/src/lib/config/project-paths.ts
+++ b/src/lib/config/project-paths.ts
@@ -3,13 +3,14 @@ import { cwd } from 'process';
 import { getConfigContext } from './configuration-context.js';
 import { nodeIo } from '../utils/io/node-io-adapter.js';
 import type { FileReaderPort } from '../domain/utils/io-port.contract.js';
+import { toDiskCase } from '../utils/disk-case.js';
 
 export function findRootTsConfigJson(): string {
   return findRootTsConfigJsonCore(nodeIo);
 }
 
 export function findRootTsConfigJsonCore(io: FileReaderPort): string {
-  const packageJson = findPackageJson(io, cwd());
+  const packageJson = findPackageJson(io, toDiskCase(io, cwd()));
   const projectRoot = path.dirname(packageJson);
   const tsConfigBaseJson = path.join(projectRoot, 'tsconfig.base.json');
   const tsConfigJson = path.join(projectRoot, 'tsconfig.json');
@@ -38,7 +39,10 @@ export function findPackageJson(io: FileReaderPort, folder: string): string {
   );
 }
 
-export function inferProjectPath(projectPath: string | undefined): string {
+export function inferProjectPath(
+  projectPath: string | undefined,
+  io: FileReaderPort = nodeIo
+): string {
   if (!projectPath && getConfigContext().packageJson) {
     projectPath = path.dirname(getConfigContext().packageJson || '');
   }
@@ -48,7 +52,7 @@ export function inferProjectPath(projectPath: string | undefined): string {
   }
 
   if (!projectPath) {
-    projectPath = cwd();
+    projectPath = toDiskCase(io, cwd());
   }
   return projectPath;
 }

--- a/src/lib/config/remove-unused-deps.spec.ts
+++ b/src/lib/config/remove-unused-deps.spec.ts
@@ -328,35 +328,32 @@ describe('removeUnusedDeps', () => {
     });
   });
 
-  // A project that reaches none of the workspace's mappings prunes them all, which in a
-  // workspace declaring one tsconfig path per library is the common case, not a defect. The
-  // spelling mismatch that is a defect is reported from resolveUsedMappings instead — see
-  // get-used-dependencies.spec.ts.
-  describe('all-mappings-pruned trace', () => {
+  // angular-adapter#117 asked for exactly this signal: nine mappings, all pruned, nothing
+  // failing. The spelling mismatch that is often the cause is reported from
+  // resolveUsedMappings, which can name it — see get-used-dependencies.spec.ts.
+  describe('all-mappings-pruned warning', () => {
     const allPruned = /All shared mappings were pruned/;
 
-    it('does not warn when a non-empty mapping set is pruned to nothing', () => {
+    it('warns when a non-empty mapping set is pruned to nothing', () => {
       const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
-      const debug = vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
       const used: UsedDependencies = { external: new Set(), internal: {} };
       const config = makeConfig({}, { sharedMappings: { '/ws/libs/ui/index.ts': '@org/ui' } });
 
       expect(run(used, config).sharedMappings).toEqual({});
-      expect(warn).not.toHaveBeenCalledWith(expect.stringMatching(allPruned));
-      expect(debug).toHaveBeenCalledWith(expect.stringMatching(allPruned));
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(allPruned));
     });
 
     it('stays quiet when the config declared no mappings to begin with', () => {
-      const debug = vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
       const used: UsedDependencies = { external: new Set(), internal: {} };
 
       run(used, makeConfig({}));
 
-      expect(debug).not.toHaveBeenCalledWith(expect.stringMatching(allPruned));
+      expect(warn).not.toHaveBeenCalledWith(expect.stringMatching(allPruned));
     });
 
     it('stays quiet when at least one mapping survives', () => {
-      const debug = vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
       const used: UsedDependencies = {
         external: new Set(),
         internal: { '/ws/libs/reached/index.ts': '@org/reached' },
@@ -365,7 +362,7 @@ describe('removeUnusedDeps', () => {
 
       run(used, config);
 
-      expect(debug).not.toHaveBeenCalledWith(expect.stringMatching(allPruned));
+      expect(warn).not.toHaveBeenCalledWith(expect.stringMatching(allPruned));
     });
   });
 

--- a/src/lib/config/remove-unused-deps.spec.ts
+++ b/src/lib/config/remove-unused-deps.spec.ts
@@ -332,7 +332,7 @@ describe('removeUnusedDeps', () => {
   // failing. The spelling mismatch that is often the cause is reported from
   // resolveUsedMappings, which can name it — see get-used-dependencies.spec.ts.
   describe('all-mappings-pruned warning', () => {
-    const allPruned = /All shared mappings were pruned/;
+    const allPruned = /No shared mapping is reachable/;
 
     it('warns when a non-empty mapping set is pruned to nothing', () => {
       const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);

--- a/src/lib/config/remove-unused-deps.spec.ts
+++ b/src/lib/config/remove-unused-deps.spec.ts
@@ -328,6 +328,47 @@ describe('removeUnusedDeps', () => {
     });
   });
 
+  // A project that reaches none of the workspace's mappings prunes them all, which in a
+  // workspace declaring one tsconfig path per library is the common case, not a defect. The
+  // spelling mismatch that is a defect is reported from resolveUsedMappings instead — see
+  // get-used-dependencies.spec.ts.
+  describe('all-mappings-pruned trace', () => {
+    const allPruned = /All shared mappings were pruned/;
+
+    it('does not warn when a non-empty mapping set is pruned to nothing', () => {
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const debug = vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+      const used: UsedDependencies = { external: new Set(), internal: {} };
+      const config = makeConfig({}, { sharedMappings: { '/ws/libs/ui/index.ts': '@org/ui' } });
+
+      expect(run(used, config).sharedMappings).toEqual({});
+      expect(warn).not.toHaveBeenCalledWith(expect.stringMatching(allPruned));
+      expect(debug).toHaveBeenCalledWith(expect.stringMatching(allPruned));
+    });
+
+    it('stays quiet when the config declared no mappings to begin with', () => {
+      const debug = vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+      const used: UsedDependencies = { external: new Set(), internal: {} };
+
+      run(used, makeConfig({}));
+
+      expect(debug).not.toHaveBeenCalledWith(expect.stringMatching(allPruned));
+    });
+
+    it('stays quiet when at least one mapping survives', () => {
+      const debug = vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+      const used: UsedDependencies = {
+        external: new Set(),
+        internal: { '/ws/libs/reached/index.ts': '@org/reached' },
+      };
+      const config = makeConfig({}, { sharedMappings: { '/ws/libs/ui/index.ts': '@org/ui' } });
+
+      run(used, config);
+
+      expect(debug).not.toHaveBeenCalledWith(expect.stringMatching(allPruned));
+    });
+  });
+
   it('does not mutate the original config', () => {
     const used: UsedDependencies = { external: new Set(['keep']), internal: {} };
     const config = makeConfig({ keep: external(), drop: external() });

--- a/src/lib/config/remove-unused-deps.ts
+++ b/src/lib/config/remove-unused-deps.ts
@@ -18,14 +18,27 @@ export function removeUnusedDeps(
     .filter(([shared, meta]) => !!meta.includeSecondaries || usedDependencies.external.has(shared))
     .reduce((acc, [shared, meta]) => ({ ...acc, [shared]: meta }), {});
 
+  // Both halves can contain wildcard-expanded imports, which the skip list has not seen yet.
+  const sharedMappings = withoutSkippedMappings(
+    { ...keptMappings(config, ctx), ...usedDependencies.internal },
+    config.skip
+  );
+
+  // Only a trace: a project that reaches none of the workspace's mappings prunes them all,
+  // and in a workspace whose tsconfig declares one path per library that is the common case.
+  // The mismatch this used to warn about is reported from resolveUsedMappings, which can tell
+  // the two apart.
+  if (Object.keys(config.sharedMappings).length > 0 && Object.keys(sharedMappings).length === 0) {
+    logger.debug(
+      'All shared mappings were pruned as unreachable from the entry points. Disable the ' +
+        "'ignoreUnusedDeps' feature to publish them anyway."
+    );
+  }
+
   return {
     ...config,
     shared: filteredDependencies,
-    // Both halves can contain wildcard-expanded imports, which the skip list has not seen yet.
-    sharedMappings: withoutSkippedMappings(
-      { ...keptMappings(config, ctx), ...usedDependencies.internal },
-      config.skip
-    ),
+    sharedMappings,
   };
 }
 

--- a/src/lib/config/remove-unused-deps.ts
+++ b/src/lib/config/remove-unused-deps.ts
@@ -24,15 +24,13 @@ export function removeUnusedDeps(
     config.skip
   );
 
-  // Not observable otherwise: the build succeeds and remoteEntry.json is well-formed, just
-  // without the workspace libraries, surfacing as a runtime NG0201 far from the cause. Pruning
-  // the last mapping can be legitimate, so this warns rather than throws; resolveUsedMappings
-  // reports separately when a path-spelling mismatch is what made them unreachable.
+  // Invisible at build time: the build succeeds and remoteEntry.json is well-formed, just
+  // without the workspace libraries, surfacing as a runtime NG0201 far from the cause. Legitimate
+  // often enough to warn rather than throw.
   if (Object.keys(config.sharedMappings).length > 0 && Object.keys(sharedMappings).length === 0) {
     logger.warn(
-      'All shared mappings were pruned as unreachable from the entry points, so the emitted ' +
-        'remoteEntry.json advertises none of this workspace\'s libraries. The likeliest cause ' +
-        "is path resolution; disable the 'ignoreUnusedDeps' feature to publish them anyway."
+      'No shared mapping is reachable from the entry points, so remoteEntry.json will ship ' +
+        "without this workspace's libraries. Disable 'ignoreUnusedDeps' to publish them anyway."
     );
   }
 

--- a/src/lib/config/remove-unused-deps.ts
+++ b/src/lib/config/remove-unused-deps.ts
@@ -24,14 +24,15 @@ export function removeUnusedDeps(
     config.skip
   );
 
-  // Only a trace: a project that reaches none of the workspace's mappings prunes them all,
-  // and in a workspace whose tsconfig declares one path per library that is the common case.
-  // The mismatch this used to warn about is reported from resolveUsedMappings, which can tell
-  // the two apart.
+  // Not observable otherwise: the build succeeds and remoteEntry.json is well-formed, just
+  // without the workspace libraries, surfacing as a runtime NG0201 far from the cause. Pruning
+  // the last mapping can be legitimate, so this warns rather than throws; resolveUsedMappings
+  // reports separately when a path-spelling mismatch is what made them unreachable.
   if (Object.keys(config.sharedMappings).length > 0 && Object.keys(sharedMappings).length === 0) {
-    logger.debug(
-      'All shared mappings were pruned as unreachable from the entry points. Disable the ' +
-        "'ignoreUnusedDeps' feature to publish them anyway."
+    logger.warn(
+      'All shared mappings were pruned as unreachable from the entry points, so the emitted ' +
+        'remoteEntry.json advertises none of this workspace\'s libraries. The likeliest cause ' +
+        "is path resolution; disable the 'ignoreUnusedDeps' feature to publish them anyway."
     );
   }
 

--- a/src/lib/core/normalize-options.spec.ts
+++ b/src/lib/core/normalize-options.spec.ts
@@ -373,6 +373,36 @@ describe('normalizeFederationOptionsCore', () => {
     vi.restoreAllMocks();
   });
 
+  // angular-adapter#117: Nx reports workspaceRoot with the invoking shell's drive-letter
+  // case, while the sharedMappings keys descend from cwd(). Every mapping then compares
+  // unequal, gets classified unused, and the build silently ships without its workspace
+  // libraries. This is the funnel the Angular adapter goes through -- it never calls
+  // federationBuilder.init, so useWorkspace alone would not cover it.
+  it('resolves mappings when the supplied workspace root is mis-cased', async () => {
+    const io = createMemoryIo()
+      .setDiskCase('c:/ws', 'C:/ws')
+      .setFile(path.join('C:/ws', 'federation.config.js'), '')
+      .setFile(path.join('C:/ws', 'libs/ui/button/index.ts'), '');
+
+    const config = makeConfig({
+      sharedMappings: { [path.join('C:/ws', 'libs/ui/*/index.ts')]: '@org/ui/*' },
+      sharedMappingsConfig: {
+        '@org/ui/*': { singleton: true, strictVersion: true, resolveGlob: true },
+      },
+    });
+
+    const result = await normalizeFederationOptionsCore(
+      { io, loadConfig: loaderFor(config) },
+      { ...baseOptions, workspaceRoot: 'c:/ws' },
+      cache
+    );
+
+    expect(result.config.sharedMappings).toEqual({
+      [path.join('C:/ws', 'libs/ui/button/index.ts')]: '@org/ui/button',
+    });
+    expect(result.options.workspaceRoot).toBe(path.normalize('C:/ws'));
+  });
+
   // resolveGlob is a guess, so it drops non-barrel matches before they can be published.
   it('does not throw for non-barrel files a resolveGlob wildcard matched', async () => {
     const io = createMemoryIo()

--- a/src/lib/core/normalize-options.spec.ts
+++ b/src/lib/core/normalize-options.spec.ts
@@ -403,6 +403,24 @@ describe('normalizeFederationOptionsCore', () => {
     expect(result.options.workspaceRoot).toBe(path.normalize('C:/ws'));
   });
 
+  // packageJson seeds folderOf() in resolve-shared-dirs and bundle-shared, so leaving it
+  // mis-cased would keep the linked-dep watch set and the shared-bundle content signals on
+  // the spelling the corrected workspaceRoot just moved away from.
+  it('resolves the supplied packageJson to its on-disk spelling', async () => {
+    const io = createMemoryIo()
+      .setDiskCase('c:/ws', 'C:/ws')
+      .setDiskCase('c:/ws/package.json', 'C:/ws/package.json')
+      .setFile(path.join('C:/ws', 'federation.config.js'), '');
+
+    const result = await normalizeFederationOptionsCore(
+      { io, loadConfig: loaderFor(makeConfig()) },
+      { ...baseOptions, workspaceRoot: 'c:/ws', packageJson: 'c:/ws/package.json' },
+      cache
+    );
+
+    expect(result.options.packageJson).toBe(path.normalize('C:/ws/package.json'));
+  });
+
   // resolveGlob is a guess, so it drops non-barrel matches before they can be published.
   it('does not throw for non-barrel files a resolveGlob wildcard matched', async () => {
     const io = createMemoryIo()

--- a/src/lib/core/normalize-options.ts
+++ b/src/lib/core/normalize-options.ts
@@ -66,6 +66,7 @@ export async function normalizeFederationOptionsCore<TBundlerCache = undefined>(
    */
 
   const workspaceRoot = toDiskCase(deps.io, options.workspaceRoot);
+  const packageJson = options.packageJson && toDiskCase(deps.io, options.packageJson);
 
   const fullConfigPath = path.join(workspaceRoot, options.federationConfig);
 
@@ -95,6 +96,7 @@ export async function normalizeFederationOptionsCore<TBundlerCache = undefined>(
   const normalizedOptions: NormalizedFederationOptions<TBundlerCache> = {
     ...options,
     workspaceRoot,
+    ...(packageJson && { packageJson }),
     entryPoints: options.entryPoints ?? Object.values(config.exposes ?? {}).map(e => e.file),
     projectName,
     cacheExternalArtifacts: options.cacheExternalArtifacts ?? true,

--- a/src/lib/core/normalize-options.ts
+++ b/src/lib/core/normalize-options.ts
@@ -16,6 +16,7 @@ import { getDefaultCachePath } from './cache/cache-persistence.js';
 import { getUsedDependenciesFactory } from '../config/get-used-dependencies.js';
 import { logger } from '../utils/logger.js';
 import { normalizePackageName } from '../utils/normalize.js';
+import { toDiskCase } from '../utils/disk-case.js';
 
 type ConfigLoader = (fullConfigPath: string) => Promise<NormalizedFederationConfig>;
 
@@ -63,7 +64,12 @@ export async function normalizeFederationOptionsCore<TBundlerCache = undefined>(
   /**
    * Step 1: normalizing config
    */
-  const fullConfigPath = path.join(options.workspaceRoot, options.federationConfig);
+
+  // Before loadConfig: withNativeFederation() runs during that import and derives the
+  // sharedMappings keys, which are string-compared against paths built from this root.
+  const workspaceRoot = toDiskCase(deps.io, options.workspaceRoot);
+
+  const fullConfigPath = path.join(workspaceRoot, options.federationConfig);
 
   if (!deps.io.exists(fullConfigPath)) {
     throw new Error('Expected ' + fullConfigPath);
@@ -79,7 +85,7 @@ export async function normalizeFederationOptionsCore<TBundlerCache = undefined>(
   const suppliedCache =
     cache ??
     (createFederationCache(
-      getDefaultCachePath(options.workspaceRoot)
+      getDefaultCachePath(workspaceRoot)
     ) as FederationCache<TBundlerCache>);
 
   const federationCache: FederationCache<TBundlerCache> = {
@@ -90,6 +96,7 @@ export async function normalizeFederationOptionsCore<TBundlerCache = undefined>(
 
   const normalizedOptions: NormalizedFederationOptions<TBundlerCache> = {
     ...options,
+    workspaceRoot,
     entryPoints: options.entryPoints ?? Object.values(config.exposes ?? {}).map(e => e.file),
     projectName,
     cacheExternalArtifacts: options.cacheExternalArtifacts ?? true,
@@ -107,12 +114,12 @@ export async function normalizeFederationOptionsCore<TBundlerCache = undefined>(
     logger.debug('Nothing is shared, skipping the used dependency scan.');
   } else if (config.features.ignoreUnusedDeps) {
     const getUsedDeps = (deps.usedDependenciesFactory ?? getUsedDependenciesFactory)(
-      options.workspaceRoot,
+      workspaceRoot,
       options.entryPoints
     );
     config = removeUnusedDeps(getUsedDeps(config), config, {
       io: deps.io,
-      workspaceRoot: options.workspaceRoot,
+      workspaceRoot,
     });
     logger.info('Removed unused dependencies.');
     logger.debug(
@@ -121,7 +128,7 @@ export async function normalizeFederationOptionsCore<TBundlerCache = undefined>(
   } else {
     config.sharedMappings = expandOrDropWildcards(config, {
       io: deps.io,
-      workspaceRoot: options.workspaceRoot,
+      workspaceRoot,
     });
   }
 

--- a/src/lib/core/normalize-options.ts
+++ b/src/lib/core/normalize-options.ts
@@ -65,8 +65,6 @@ export async function normalizeFederationOptionsCore<TBundlerCache = undefined>(
    * Step 1: normalizing config
    */
 
-  // Before loadConfig: withNativeFederation() runs during that import and derives the
-  // sharedMappings keys, which are string-compared against paths built from this root.
   const workspaceRoot = toDiskCase(deps.io, options.workspaceRoot);
 
   const fullConfigPath = path.join(workspaceRoot, options.federationConfig);

--- a/src/lib/domain/utils/io-port.contract.ts
+++ b/src/lib/domain/utils/io-port.contract.ts
@@ -23,6 +23,8 @@ export interface FileReaderPort {
   /** Immediate child entry names (not full paths). Empty array on ENOENT, never throws. */
   readDir(path: string): string[];
   realpath(path: string): string;
+  /** The path as disk spells it, including case on case-insensitive filesystems. */
+  realpathNative(path: string): string;
   stat(path: string): StatInfo | null;
 }
 

--- a/src/lib/utils/disk-case.spec.ts
+++ b/src/lib/utils/disk-case.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import * as path from 'path';
+import { toDiskCase } from './disk-case.js';
+import { createMemoryIo } from './io/__test-helpers__/memory-io.js';
+import type { FileReaderPort } from '../domain/utils/io-port.contract.js';
+
+// The reported bug is Windows-only, so the fixtures use drive-letter paths. memory-io keys
+// them verbatim, which lets the case-only distinction survive a case-sensitive CI host.
+const reporting = (spelling: string): FileReaderPort =>
+  ({ realpathNative: () => spelling }) as unknown as FileReaderPort;
+
+describe('toDiskCase', () => {
+  it('corrects a case-only difference', () => {
+    const io = createMemoryIo().setDiskCase('c:/ws', 'C:/ws');
+    expect(toDiskCase(io, 'c:/ws')).toBe(path.normalize('C:/ws'));
+  });
+
+  it('accepts a correction that also differs in separator style', () => {
+    expect(toDiskCase(reporting('C:/ws'), 'c:\\ws')).toBe(path.normalize('C:/ws'));
+  });
+
+  it('is a no-op when input and on-disk spelling already agree', () => {
+    const root = path.resolve('/ws');
+    expect(toDiskCase(reporting(root), root)).toBe(root);
+  });
+
+  // pnpm, npm link and preserveSymlinks all rely on the caller's own spelling being kept.
+  it('returns the input unchanged when a symlink resolves to a different path', () => {
+    const io = createMemoryIo().setSymlink('/ws/libs/ui', '/ws/packages/ui');
+    expect(toDiskCase(io, '/ws/libs/ui')).toBe('/ws/libs/ui');
+  });
+
+  // The adapter returns the input on ENOENT, and a platform reporting a '\\?\' prefix or a
+  // substituted drive lands here too: more than case differs, so nothing is applied.
+  it('returns the input unchanged when the reported spelling differs by more than case', () => {
+    expect(toDiskCase(reporting('\\\\?\\C:\\ws'), 'c:/ws')).toBe('c:/ws');
+  });
+
+  // A path that does not exist, and an empty root, both come back identical from the
+  // adapter; normalizing them anyway would turn '' into '.'.
+  it('returns an unchanged reported spelling verbatim', () => {
+    expect(toDiskCase(reporting(''), '')).toBe('');
+    expect(toDiskCase(reporting('c:/ws'), 'c:/ws')).toBe('c:/ws');
+  });
+
+  it('ignores a trailing slash on either side', () => {
+    expect(toDiskCase(reporting('C:/ws'), 'c:/ws/')).toBe(path.normalize('C:/ws'));
+  });
+});

--- a/src/lib/utils/disk-case.ts
+++ b/src/lib/utils/disk-case.ts
@@ -3,11 +3,9 @@ import { toPosix } from './path-patterns.js';
 import type { FileReaderPort } from '../domain/utils/io-port.contract.js';
 
 /**
- * Re-spells `p` the way disk spells it, but only when the two differ by case alone.
- *
- * Every absolute path that gets string-compared later descends from a root supplied by
- * the invoking tool, and on Windows two tools can report the same root with different
- * drive-letter case. Correcting it at the root keeps the comparison sites unchanged.
+ * Every absolute path that gets string-compared later descends from a root supplied by the
+ * invoking tool, and on Windows two tools can report one root with different drive-letter case.
+ * Correcting it at the root keeps the comparison sites unchanged.
  */
 export function toDiskCase(io: FileReaderPort, p: string): string {
   const real = io.realpathNative(p);
@@ -15,10 +13,9 @@ export function toDiskCase(io: FileReaderPort, p: string): string {
   return path.normalize(real);
 }
 
-// realpath also resolves symlinks; accepting only a case-only difference keeps this a pure
-// case correction, so link-based setups (pnpm, npm link, preserveSymlinks) are unaffected.
-// Separator style and trailing slashes are stripped first, otherwise 'c:/x' and 'C:\x' never
-// compare equal and the guard rejects a correction it should accept.
+// realpath also resolves symlinks, so anything broader than a case difference would move pnpm,
+// `npm link` and `preserveSymlinks` off the path they were handed. Separator style and trailing
+// slashes are stripped first, or 'c:/x' and 'C:\x' never compare equal.
 function differsOnlyByCase(a: string, b: string): boolean {
   const strip = (s: string) => toPosix(s).replace(/\/+$/, '').toLowerCase();
   return strip(a) === strip(b);

--- a/src/lib/utils/disk-case.ts
+++ b/src/lib/utils/disk-case.ts
@@ -1,0 +1,25 @@
+import * as path from 'path';
+import { toPosix } from './path-patterns.js';
+import type { FileReaderPort } from '../domain/utils/io-port.contract.js';
+
+/**
+ * Re-spells `p` the way disk spells it, but only when the two differ by case alone.
+ *
+ * Every absolute path that gets string-compared later descends from a root supplied by
+ * the invoking tool, and on Windows two tools can report the same root with different
+ * drive-letter case. Correcting it at the root keeps the comparison sites unchanged.
+ */
+export function toDiskCase(io: FileReaderPort, p: string): string {
+  const real = io.realpathNative(p);
+  if (real === p || !differsOnlyByCase(real, p)) return p;
+  return path.normalize(real);
+}
+
+// realpath also resolves symlinks; accepting only a case-only difference keeps this a pure
+// case correction, so link-based setups (pnpm, npm link, preserveSymlinks) are unaffected.
+// Separator style and trailing slashes are stripped first, otherwise 'c:/x' and 'C:\x' never
+// compare equal and the guard rejects a correction it should accept.
+function differsOnlyByCase(a: string, b: string): boolean {
+  const strip = (s: string) => toPosix(s).replace(/\/+$/, '').toLowerCase();
+  return strip(a) === strip(b);
+}

--- a/src/lib/utils/io/__test-helpers__/memory-io.ts
+++ b/src/lib/utils/io/__test-helpers__/memory-io.ts
@@ -15,6 +15,8 @@ export interface MemoryIo extends IoPort {
   setDir(dirPath: string): MemoryIo;
   /** Register `linkPath` as a symlink resolving to `target` (for realpath/stat). */
   setSymlink(linkPath: string, target: string): MemoryIo;
+  /** Register the on-disk spelling `realpathNative` should report for `path`. */
+  setDiskCase(path: string, spelling: string): MemoryIo;
   /** Set an entry's mtime (ms) reported by `stat`. */
   setMtime(filePath: string, mtimeMs: number): MemoryIo;
   files(): string[];
@@ -29,9 +31,18 @@ export function createMemoryIo(): MemoryIo {
   const watchers = new Map<string, Array<(filename: string | null) => void>>();
   const symlinks = new Map<string, string>();
   const mtimes = new Map<string, number>();
+  const diskCase = new Map<string, string>();
 
   const encode = (data: string | Uint8Array): Uint8Array =>
     typeof data === 'string' ? new TextEncoder().encode(data) : data;
+
+  const resolveLinks = (key: string): string => {
+    for (const [link, target] of symlinks) {
+      if (key === link) return target;
+      if (key.startsWith(link + '/')) return target + key.slice(link.length);
+    }
+    return key;
+  };
 
   const registerDirs = (key: string) => {
     let dir = path.posix.dirname(key);
@@ -69,6 +80,10 @@ export function createMemoryIo(): MemoryIo {
     },
     setSymlink(linkPath, target) {
       symlinks.set(toKey(linkPath), toKey(target));
+      return io;
+    },
+    setDiskCase(p, spelling) {
+      diskCase.set(toKey(p), spelling);
       return io;
     },
     setMtime(filePath, mtimeMs) {
@@ -112,12 +127,14 @@ export function createMemoryIo(): MemoryIo {
       return [...names];
     },
     realpath(p) {
+      return resolveLinks(toKey(p));
+    },
+    // A registered spelling is returned verbatim: toKey() would re-resolve it against the
+    // real cwd, which on a case-sensitive host would defeat the case-only comparison the
+    // caller is about to make.
+    realpathNative(p) {
       const key = toKey(p);
-      for (const [link, target] of symlinks) {
-        if (key === link) return target;
-        if (key.startsWith(link + '/')) return target + key.slice(link.length);
-      }
-      return key;
+      return diskCase.get(key) ?? resolveLinks(key);
     },
     stat(p): StatInfo | null {
       const key = toKey(p);

--- a/src/lib/utils/io/node-io-adapter.spec.ts
+++ b/src/lib/utils/io/node-io-adapter.spec.ts
@@ -31,6 +31,22 @@ describe('nodeIo', () => {
     });
   });
 
+  describe('realpathNative', () => {
+    it('resolves a symlink to its target', () => {
+      const target = path.join(root, 'target');
+      const link = path.join(root, 'link');
+      fs.mkdirSync(target);
+      fs.symlinkSync(target, link, 'dir');
+
+      expect(nodeIo.realpathNative(link)).toBe(fs.realpathSync.native(target));
+    });
+
+    it('returns the input unchanged when the path does not exist', () => {
+      const missing = path.join(root, 'nope');
+      expect(nodeIo.realpathNative(missing)).toBe(missing);
+    });
+  });
+
   describe('stat', () => {
     it('flags a symlink without following it', () => {
       const target = path.join(root, 'target');

--- a/src/lib/utils/io/node-io-adapter.ts
+++ b/src/lib/utils/io/node-io-adapter.ts
@@ -48,9 +48,8 @@ export const nodeIo: IoPort = {
       return path;
     }
   },
-  // The JS realpathSync walks the components of the *input string* and only rewrites the
-  // ones that are symlinks, so it preserves the caller's casing. Only the native variant
-  // goes to the filesystem for the stored spelling.
+  // Only the native variant reports the spelling stored on disk: the JS realpathSync walks the
+  // components of the input string and rewrites only the ones that are symlinks.
   realpathNative(path) {
     try {
       return fs.realpathSync.native(path);

--- a/src/lib/utils/io/node-io-adapter.ts
+++ b/src/lib/utils/io/node-io-adapter.ts
@@ -48,6 +48,16 @@ export const nodeIo: IoPort = {
       return path;
     }
   },
+  // The JS realpathSync walks the components of the *input string* and only rewrites the
+  // ones that are symlinks, so it preserves the caller's casing. Only the native variant
+  // goes to the filesystem for the stored spelling.
+  realpathNative(path) {
+    try {
+      return fs.realpathSync.native(path);
+    } catch {
+      return path;
+    }
+  },
   stat(path): StatInfo | null {
     try {
       const s = fs.lstatSync(path);


### PR DESCRIPTION
Fixes symptom 1 of native-federation/angular-adapter#117. Symptom 2 is the adapter's
half, in native-federation/angular-adapter#126 — independent changes, but see
*Interaction* below for why they should land together.

## Problem

Windows reports the same directory under whatever drive-letter case the caller used.
Per the issue, the two sources disagree in a fixed direction:

| Source | Case |
| --- | --- |
| Nx `workspaceRoot` / `NX_WORKSPACE_ROOT` | inherited from the invoking shell (`c:\…`) |
| `process.cwd()` | as stored on disk (`C:\…`) |

Every absolute path that gets string-compared in the pipeline descends from one of the
two:

| Consumer | Root it derives from |
| --- | --- |
| `sharedMappings` keys (`mapped-paths.ts`, via `findRootTsConfigJson()`) | `cwd()` |
| reachability scan (`get-used-dependencies.ts`) | `options.workspaceRoot` |
| wildcard expansion (`expand-mappings.ts`) | `options.workspaceRoot` |
| bundling / versioning (`bundle-exposed-and-mappings.ts`) | `options.workspaceRoot` |

Windows treats `c:\ws` and `C:\ws` as one directory; `matchMapping` and
`isSharedMapping` do not. Every workspace mapping is then classified as unused,
`removeUnusedDeps` drops it, and the build succeeds while `remoteEntry.json` silently
ships without its workspace libraries. The reporter's host published 62 shared entries
instead of 71, and the first remote to hydrate died with `NG0201` at runtime, far from
the cause.

## Fix

`toDiskCase(io, path)` re-spells a root the way `fs.realpathSync.native` reports it, but
only when the two differ **by case alone**. `realpath` also resolves symlinks, so
accepting a broader difference would change what pnpm, `npm link` and `preserveSymlinks`
resolve to. (The issue suggested plain `fs.realpathSync`, which would have rewritten
those setups to fix a Windows-only bug.)

The `.native` variant is load-bearing: the JS `realpathSync` walks the components of the
*input string* and rewrites only the ones that are symlinks, so it preserves the caller's
casing and cannot fix this.

Applied where an externally-supplied root enters, not at each comparison site:

- `normalizeFederationOptionsCore` — the funnel. The Angular adapter reaches core through
  `normalizeFederationOptions` and never calls `federationBuilder.init`, so fixing only
  `useWorkspace` would miss the Angular path. This is the correction that closes the bug,
  because `workspaceRoot` is the mis-cased side.
- `useWorkspace` — the esbuild-adapter path, via `federationBuilder.init`.
- `options.packageJson`, at the same funnel. It seeds `folderOf()` in
  `resolve-shared-dirs.ts` and `bundle-shared.ts`, so leaving it alone would strand the
  linked-dep watch set and the shared-bundle content signals on the spelling the corrected
  `workspaceRoot` has just moved away from.
- both `cwd()` sites in `project-paths.ts`. The issue reports `cwd()` as already carrying
  the disk case, so this is not what closes the bug — it is what keeps the fix safe for the
  workspaces most likely to install it. The mitigation described in the issue re-anchors
  `cwd()` *onto* the mis-cased `NX_WORKSPACE_ROOT`, which makes `cwd()` the mis-cased side.
  Without this, a workspace running that workaround would upgrade into a corrected
  `workspaceRoot` and a deliberately mis-cased `cwd()`, and diverge again inside a build that
  looks patched.

The third `cwd()` — sheriff's traversal root in `get-used-dependencies.ts` — is deliberately
left alone. Sheriff relativizes every path it returns against that root, so its spelling
cancels before `resolveUsedMappings` re-joins those paths onto `workspaceRoot`.

## Diagnostics

Two separate signals, because they answer different questions and neither subsumes the
other.

`removeUnusedDeps` **warns** when a non-empty `sharedMappings` set is pruned to empty.
This is the signal the issue asked for by name, and the reporter's own case is exactly it
— nine mappings, all pruned, nothing failing. Pruning the last mapping can be legitimate,
so it warns rather than throws.

`resolveUsedMappings` **warns** when an import reaches a mapping only once case is
ignored, and names one. This identifies the *cause* the emptied set cannot distinguish
from a project that legitimately reaches no workspace library. It is also the only check
that sees a **partial** mismatch: a mis-cased tsconfig `paths` value —
`"@org/ui": ["libs/UI/index.ts"]` where disk says `libs/ui` — resolves fine for
TypeScript on a case-insensitive filesystem, is not corrected by `toDiskCase` (which
corrects roots, not per-mapping values), and silently drops just that one library while
every other mapping still resolves.

## Interaction with angular-adapter#126

Core now re-spells the root it is given and returns it on
`normalized.options.workspaceRoot`. Adapters that derive paths from a root they obtained
elsewhere should either take it from there or re-spell their own, or a single build runs
with core's paths canonical and its own still mis-cased — a split root, which is what
#126 fixes on its side.

## Notes

- **Not simply inert off Windows.** macOS's default APFS is case-insensitive, so a
  mis-cased root is corrected there too. On a case-sensitive filesystem the input comes back
  unchanged, with one exception: `realpathSync.native` strips a trailing slash, and the guard
  compares with trailing slashes stripped, so `/ws/` normalises to `/ws`. That is inert —
  every consumer joins onto the root rather than concatenating — but it is a change, not an
  identity. A platform reporting a spelling that differs by more than case (a `\\?\` prefix,
  a substituted drive) is rejected by the guard and the input returned, which is today's
  behaviour.
- **Regression guards.** Stubbing `toDiskCase` to `return p` fails 7 tests, including
  `normalize-options.spec.ts` producing the empty `sharedMappings` that is the reported
  symptom.
- **Not verified on Windows.** Needs the reporter to confirm against a pre-release:
  building the same workspace from `/c/…` and `/C/…` must produce matching `shared[]`
  arrays.
- `FileReaderPort` gained `realpathNative`. It is not exported from any package
  entrypoint, so this breaks no external implementor.

## Deliberately out of scope

Case-insensitive comparison in `matchMapping` / `isSharedMapping`. It is whack-a-mole
across five files plus the adapter and Angular's own `typeScriptFileCache`, and it only
fixes the match: `resolveUsedMappings` keys by the mis-cased path, so the wrong spelling
still reaches `remoteEntry.json`. `match-mapping.ts` is unchanged by this PR; the
case-folded probe behind the second warning lives in `get-used-dependencies.ts`, is
diagnostic only, and never decides whether a mapping is used.
