### PR TITLE
feat: support object-form requiredVersion with range formatting (exact | ^ | ~ | minor | patch)

### DIFF
--- a/src/lib/config/share-utils.spec.ts
+++ b/src/lib/config/share-utils.spec.ts
@@ -73,101 +73,67 @@ describe('shareCore (end-to-end via injected repository)', () => {
 
     expect(Object.keys(result)).toEqual(['mylib']);
   });
-});
 
-describe('shareAllCore (end-to-end via injected repository)', () => {
-  const PROJECT = path.resolve('/ws/app');
-
-  it('builds shared externals from the dependency map, honouring skip list and overrides', () => {
+  it('applies prefix when requiredVersion is auto with prefix and base is exact semver', () => {
     const io = createMemoryIo().setFile(
       path.join(PROJECT, 'package.json'),
-      JSON.stringify({ dependencies: { mylib: '^1.2.3', skipme: '^2.0.0', overridden: '^3.0.0' } })
+      JSON.stringify({ dependencies: { mylib: '1.2.3' } })
     );
     const repo = createPackageJsonRepository(io);
 
-    const result = shareAllCore(
+    const result = shareCore(
       io,
-      { singleton: true, includeSecondaries: false },
-      {
-        projectPath: PROJECT,
-        skipList: ['skipme'],
-        overrides: {
-          overridden: { singleton: false, requiredVersion: '~3.1.0', includeSecondaries: false },
-        },
-      },
+      { mylib: { singleton: true, requiredVersion: { mode: 'auto', prefix: 'v' }, includeSecondaries: false } },
+      PROJECT,
+      DEFAULT_SKIP_LIST,
       repo
     );
 
-    expect(Object.keys(result!).sort()).toEqual(['mylib', 'overridden']);
-    expect(result!['mylib']).toMatchObject({ singleton: true, requiredVersion: '^1.2.3' });
-    expect(result!['overridden']).toMatchObject({ singleton: false, requiredVersion: '~3.1.0' });
-  });
-
-  it('patches a shared external in place', () => {
-    const io = createMemoryIo().setFile(
-      path.join(PROJECT, 'package.json'),
-      JSON.stringify({ dependencies: { mylib: '^1.2.3' } })
-    );
-    const repo = createPackageJsonRepository(io);
-
-    const result = shareAllCore(
-      io,
-      { singleton: true, includeSecondaries: false },
-      { projectPath: PROJECT, patchList: { mylib: { singleton: false, strictVersion: true } } },
-      repo
-    );
-
-    expect(result!['mylib']).toMatchObject({
-      singleton: false,
-      strictVersion: true,
-      requiredVersion: '^1.2.3',
+    expect(result['mylib']).toMatchObject({
+      singleton: true,
+      requiredVersion: 'v1.2.3',
+      version: '1.2.3',
     });
   });
 
-  it('ignores a patch for an external that is not shared and warns', () => {
+  it('force-replaces prefix for caret when force=true', () => {
     const io = createMemoryIo().setFile(
       path.join(PROJECT, 'package.json'),
       JSON.stringify({ dependencies: { mylib: '^1.2.3' } })
     );
     const repo = createPackageJsonRepository(io);
-    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
 
-    const result = shareAllCore(
+    const result = shareCore(
       io,
-      { singleton: true, includeSecondaries: false },
-      { projectPath: PROJECT, patchList: { doesnotexist: { singleton: false } } },
+      { mylib: { singleton: true, requiredVersion: { mode: 'auto', prefix: 'v', force: true }, includeSecondaries: false } },
+      PROJECT,
+      DEFAULT_SKIP_LIST,
       repo
     );
 
-    expect(Object.keys(result!)).toEqual(['mylib']);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('not a shared external'));
-    warn.mockRestore();
+    expect(result['mylib']).toMatchObject({
+      singleton: true,
+      requiredVersion: 'v1.2.3',
+      version: '1.2.3',
+    });
   });
 
-  it('ignores a patch for an external that is shadowed by overrides and warns', () => {
+  it('does not change complex ranges when applying auto prefix', () => {
+    const complex = '>=1.0.0 <2.0.0';
     const io = createMemoryIo().setFile(
       path.join(PROJECT, 'package.json'),
-      JSON.stringify({ dependencies: { overridden: '^3.0.0' } })
+      JSON.stringify({ dependencies: { mylib: complex } })
     );
     const repo = createPackageJsonRepository(io);
-    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
 
-    const result = shareAllCore(
+    const result = shareCore(
       io,
-      { singleton: true, includeSecondaries: false },
-      {
-        projectPath: PROJECT,
-        overrides: {
-          overridden: { singleton: false, requiredVersion: '~3.1.0', includeSecondaries: false },
-        },
-        patchList: { overridden: { singleton: true } },
-      },
+      { mylib: { singleton: true, requiredVersion: { mode: 'auto', prefix: 'v' }, includeSecondaries: false } },
+      PROJECT,
+      DEFAULT_SKIP_LIST,
       repo
     );
 
-    // The override value wins; the patch is not applied.
-    expect(result!['overridden']).toMatchObject({ singleton: false, requiredVersion: '~3.1.0' });
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('mutually exclusive'));
-    warn.mockRestore();
+    expect(result['mylib'].requiredVersion).toBe(complex);
   });
 });

--- a/src/lib/config/share-utils.spec.ts
+++ b/src/lib/config/share-utils.spec.ts
@@ -74,7 +74,6 @@ describe('shareCore (end-to-end via injected repository)', () => {
     expect(Object.keys(result)).toEqual(['mylib']);
   });
 
-  // New tests for auto requiredVersion with prefix/force behaviour
   it('applies prefix when requiredVersion is auto with prefix and base is exact semver', () => {
     const io = createMemoryIo().setFile(
       path.join(PROJECT, 'package.json'),

--- a/src/lib/config/share-utils.spec.ts
+++ b/src/lib/config/share-utils.spec.ts
@@ -74,6 +74,7 @@ describe('shareCore (end-to-end via injected repository)', () => {
     expect(Object.keys(result)).toEqual(['mylib']);
   });
 
+  // New tests for auto requiredVersion with prefix/force behaviour
   it('applies prefix when requiredVersion is auto with prefix and base is exact semver', () => {
     const io = createMemoryIo().setFile(
       path.join(PROJECT, 'package.json'),
@@ -187,5 +188,102 @@ describe('shareCore (end-to-end via injected repository)', () => {
     );
 
     expect(resultForce['mylib'].requiredVersion).toBe('~1.2.3');
+  });
+});
+
+describe('shareAllCore (end-to-end via injected repository)', () => {
+  const PROJECT = path.resolve('/ws/app');
+
+  it('builds shared externals from the dependency map, honouring skip list and overrides', () => {
+    const io = createMemoryIo().setFile(
+      path.join(PROJECT, 'package.json'),
+      JSON.stringify({ dependencies: { mylib: '^1.2.3', skipme: '^2.0.0', overridden: '^3.0.0' } })
+    );
+    const repo = createPackageJsonRepository(io);
+
+    const result = shareAllCore(
+      io,
+      { singleton: true, includeSecondaries: false },
+      {
+        projectPath: PROJECT,
+        skipList: ['skipme'],
+        overrides: {
+          overridden: { singleton: false, requiredVersion: '~3.1.0', includeSecondaries: false },
+        },
+      },
+      repo
+    );
+
+    expect(Object.keys(result!).sort()).toEqual(['mylib', 'overridden']);
+    expect(result!['mylib']).toMatchObject({ singleton: true, requiredVersion: '^1.2.3' });
+    expect(result!['overridden']).toMatchObject({ singleton: false, requiredVersion: '~3.1.0' });
+  });
+
+  it('patches a shared external in place', () => {
+    const io = createMemoryIo().setFile(
+      path.join(PROJECT, 'package.json'),
+      JSON.stringify({ dependencies: { mylib: '^1.2.3' } })
+    );
+    const repo = createPackageJsonRepository(io);
+
+    const result = shareAllCore(
+      io,
+      { singleton: true, includeSecondaries: false },
+      { projectPath: PROJECT, patchList: { mylib: { singleton: false, strictVersion: true } } },
+      repo
+    );
+
+    expect(result!['mylib']).toMatchObject({
+      singleton: false,
+      strictVersion: true,
+      requiredVersion: '^1.2.3',
+    });
+  });
+
+  it('ignores a patch for an external that is not shared and warns', () => {
+    const io = createMemoryIo().setFile(
+      path.join(PROJECT, 'package.json'),
+      JSON.stringify({ dependencies: { mylib: '^1.2.3' } })
+    );
+    const repo = createPackageJsonRepository(io);
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const result = shareAllCore(
+      io,
+      { singleton: true, includeSecondaries: false },
+      { projectPath: PROJECT, patchList: { doesnotexist: { singleton: false } } },
+      repo
+    );
+
+    expect(Object.keys(result!)).toEqual(['mylib']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('not a shared external'));
+    warn.mockRestore();
+  });
+
+  it('ignores a patch for an external that is shadowed by overrides and warns', () => {
+    const io = createMemoryIo().setFile(
+      path.join(PROJECT, 'package.json'),
+      JSON.stringify({ dependencies: { overridden: '^3.0.0' } })
+    );
+    const repo = createPackageJsonRepository(io);
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const result = shareAllCore(
+      io,
+      { singleton: true, includeSecondaries: false },
+      {
+        projectPath: PROJECT,
+        overrides: {
+          overridden: { singleton: false, requiredVersion: '~3.1.0', includeSecondaries: false },
+        },
+        patchList: { overridden: { singleton: true } },
+      },
+      repo
+    );
+
+    // The override value wins; the patch is not applied.
+    expect(result!['overridden']).toMatchObject({ singleton: false, requiredVersion: '~3.1.0' });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('mutually exclusive'));
+    warn.mockRestore();
   });
 });

--- a/src/lib/config/share-utils.spec.ts
+++ b/src/lib/config/share-utils.spec.ts
@@ -74,7 +74,7 @@ describe('shareCore (end-to-end via injected repository)', () => {
     expect(Object.keys(result)).toEqual(['mylib']);
   });
 
-  it('applies prefix when requiredVersion is auto with prefix and base is exact semver', () => {
+  it('applies caret range when requiredVersion is auto with range "^" and base is exact semver', () => {
     const io = createMemoryIo().setFile(
       path.join(PROJECT, 'package.json'),
       JSON.stringify({ dependencies: { mylib: '1.2.3' } })
@@ -83,7 +83,7 @@ describe('shareCore (end-to-end via injected repository)', () => {
 
     const result = shareCore(
       io,
-      { mylib: { singleton: true, requiredVersion: { mode: 'auto', prefix: 'v' }, includeSecondaries: false } },
+      { mylib: { singleton: true, requiredVersion: { range: '^' }, includeSecondaries: false } },
       PROJECT,
       DEFAULT_SKIP_LIST,
       repo
@@ -91,53 +91,12 @@ describe('shareCore (end-to-end via injected repository)', () => {
 
     expect(result['mylib']).toMatchObject({
       singleton: true,
-      requiredVersion: 'v1.2.3',
+      requiredVersion: '^1.2.3',
       version: '1.2.3',
     });
   });
 
-  it('force-replaces prefix for caret when force=true', () => {
-    const io = createMemoryIo().setFile(
-      path.join(PROJECT, 'package.json'),
-      JSON.stringify({ dependencies: { mylib: '^1.2.3' } })
-    );
-    const repo = createPackageJsonRepository(io);
-
-    const result = shareCore(
-      io,
-      { mylib: { singleton: true, requiredVersion: { mode: 'auto', prefix: 'v', force: true }, includeSecondaries: false } },
-      PROJECT,
-      DEFAULT_SKIP_LIST,
-      repo
-    );
-
-    expect(result['mylib']).toMatchObject({
-      singleton: true,
-      requiredVersion: 'v1.2.3',
-      version: '1.2.3',
-    });
-  });
-
-  it('does not change complex ranges when applying auto prefix', () => {
-    const complex = '>=1.0.0 <2.0.0';
-    const io = createMemoryIo().setFile(
-      path.join(PROJECT, 'package.json'),
-      JSON.stringify({ dependencies: { mylib: complex } })
-    );
-    const repo = createPackageJsonRepository(io);
-
-    const result = shareCore(
-      io,
-      { mylib: { singleton: true, requiredVersion: { mode: 'auto', prefix: 'v' }, includeSecondaries: false } },
-      PROJECT,
-      DEFAULT_SKIP_LIST,
-      repo
-    );
-
-    expect(result['mylib'].requiredVersion).toBe(complex);
-  });
-
-  it('applies tilde prefix when requested for exact semver', () => {
+  it('applies tilde range when requested for exact semver', () => {
     const io = createMemoryIo().setFile(
       path.join(PROJECT, 'package.json'),
       JSON.stringify({ dependencies: { mylib: '1.2.3' } })
@@ -146,7 +105,7 @@ describe('shareCore (end-to-end via injected repository)', () => {
 
     const result = shareCore(
       io,
-      { mylib: { singleton: true, requiredVersion: { mode: 'auto', prefix: '~' }, includeSecondaries: false } },
+      { mylib: { singleton: true, requiredVersion: { range: '~' }, includeSecondaries: false } },
       PROJECT,
       DEFAULT_SKIP_LIST,
       repo
@@ -159,34 +118,69 @@ describe('shareCore (end-to-end via injected repository)', () => {
     });
   });
 
-  it('does not overwrite an existing range prefix unless force is set', () => {
+  it('minor -> caret and patch -> tilde mapping', () => {
+    const io = createMemoryIo().setFile(
+      path.join(PROJECT, 'package.json'),
+      JSON.stringify({ dependencies: { mylib: '1.2.3' } })
+    );
+    const repo = createPackageJsonRepository(io);
+
+    const rMinor = shareCore(
+      io,
+      { mylib: { singleton: true, requiredVersion: { range: 'minor' }, includeSecondaries: false } },
+      PROJECT,
+      DEFAULT_SKIP_LIST,
+      repo
+    );
+
+    const rPatch = shareCore(
+      io,
+      { mylib: { singleton: true, requiredVersion: { range: 'patch' }, includeSecondaries: false } },
+      PROJECT,
+      DEFAULT_SKIP_LIST,
+      repo
+    );
+
+    expect(rMinor['mylib'].requiredVersion).toBe('^1.2.3');
+    expect(rPatch['mylib'].requiredVersion).toBe('~1.2.3');
+  });
+
+  it('overwrites existing simple prefix when range is provided', () => {
     const io = createMemoryIo().setFile(
       path.join(PROJECT, 'package.json'),
       JSON.stringify({ dependencies: { mylib: '^1.2.3' } })
     );
     const repo = createPackageJsonRepository(io);
 
-    // prefix '~' but force is false: should keep '^1.2.3'
-    const resultNoForce = shareCore(
+    // range '~' should overwrite '^1.2.3' -> '~1.2.3'
+    const result = shareCore(
       io,
-      { mylib: { singleton: true, requiredVersion: { mode: 'auto', prefix: '~', force: false }, includeSecondaries: false } },
+      { mylib: { singleton: true, requiredVersion: { range: '~' }, includeSecondaries: false } },
       PROJECT,
       DEFAULT_SKIP_LIST,
       repo
     );
 
-    expect(resultNoForce['mylib'].requiredVersion).toBe('^1.2.3');
+    expect(result['mylib'].requiredVersion).toBe('~1.2.3');
+  });
 
-    // same but force=true: should become '~1.2.3'
-    const resultForce = shareCore(
+  it('does not change complex ranges when applying auto range', () => {
+    const complex = '>=1.0.0 <2.0.0';
+    const io = createMemoryIo().setFile(
+      path.join(PROJECT, 'package.json'),
+      JSON.stringify({ dependencies: { mylib: complex } })
+    );
+    const repo = createPackageJsonRepository(io);
+
+    const result = shareCore(
       io,
-      { mylib: { singleton: true, requiredVersion: { mode: 'auto', prefix: '~', force: true }, includeSecondaries: false } },
+      { mylib: { singleton: true, requiredVersion: { range: '^' }, includeSecondaries: false } },
       PROJECT,
       DEFAULT_SKIP_LIST,
       repo
     );
 
-    expect(resultForce['mylib'].requiredVersion).toBe('~1.2.3');
+    expect(result['mylib'].requiredVersion).toBe(complex);
   });
 });
 

--- a/src/lib/config/share-utils.spec.ts
+++ b/src/lib/config/share-utils.spec.ts
@@ -136,4 +136,56 @@ describe('shareCore (end-to-end via injected repository)', () => {
 
     expect(result['mylib'].requiredVersion).toBe(complex);
   });
+
+  it('applies tilde prefix when requested for exact semver', () => {
+    const io = createMemoryIo().setFile(
+      path.join(PROJECT, 'package.json'),
+      JSON.stringify({ dependencies: { mylib: '1.2.3' } })
+    );
+    const repo = createPackageJsonRepository(io);
+
+    const result = shareCore(
+      io,
+      { mylib: { singleton: true, requiredVersion: { mode: 'auto', prefix: '~' }, includeSecondaries: false } },
+      PROJECT,
+      DEFAULT_SKIP_LIST,
+      repo
+    );
+
+    expect(result['mylib']).toMatchObject({
+      singleton: true,
+      requiredVersion: '~1.2.3',
+      version: '1.2.3',
+    });
+  });
+
+  it('does not overwrite an existing range prefix unless force is set', () => {
+    const io = createMemoryIo().setFile(
+      path.join(PROJECT, 'package.json'),
+      JSON.stringify({ dependencies: { mylib: '^1.2.3' } })
+    );
+    const repo = createPackageJsonRepository(io);
+
+    // prefix '~' but force is false: should keep '^1.2.3'
+    const resultNoForce = shareCore(
+      io,
+      { mylib: { singleton: true, requiredVersion: { mode: 'auto', prefix: '~', force: false }, includeSecondaries: false } },
+      PROJECT,
+      DEFAULT_SKIP_LIST,
+      repo
+    );
+
+    expect(resultNoForce['mylib'].requiredVersion).toBe('^1.2.3');
+
+    // same but force=true: should become '~1.2.3'
+    const resultForce = shareCore(
+      io,
+      { mylib: { singleton: true, requiredVersion: { mode: 'auto', prefix: '~', force: true }, includeSecondaries: false } },
+      PROJECT,
+      DEFAULT_SKIP_LIST,
+      repo
+    );
+
+    expect(resultForce['mylib'].requiredVersion).toBe('~1.2.3');
+  });
 });

--- a/src/lib/config/share-utils.ts
+++ b/src/lib/config/share-utils.ts
@@ -11,6 +11,7 @@ import { logger } from '../utils/logger.js';
 import { nodeIo } from '../utils/io/node-io-adapter.js';
 import type { FileReaderPort, GlobPort } from '../domain/utils/io-port.contract.js';
 import type {
+  AutoRequiredOptions,
   ExternalConfig,
   IncludeSecondariesOptions,
   ResolvedSharedExternalsConfig,
@@ -95,25 +96,24 @@ export function shareAllCore(
         continue;
       }
 
-      const cfgRequired = (config.requiredVersion ?? undefined) as any;
-      const inferVersion =
-        !cfgRequired ||
-        cfgRequired === 'auto' ||
-        (typeof cfgRequired === 'object' && (cfgRequired.mode === undefined || cfgRequired.mode === 'auto'));
+      const requiredVersionCfg = (config.requiredVersion ?? undefined) as
+        | string
+        | AutoRequiredOptions
+        | undefined;
+      const isAutoObject = typeof requiredVersionCfg === 'object';
+      const inferVersion = !requiredVersionCfg || requiredVersionCfg === 'auto' || isAutoObject;
 
       let requiredVersion: string;
       if (inferVersion) {
-        // versions[key] is the raw value from package.json (e.g. '^1.2.3' or '1.2.3')
-        const base = versions[key];
-        if (typeof cfgRequired === 'object' && cfgRequired.range) {
-          requiredVersion = applyAutoRequiredOptions(base, {
-            range: cfgRequired.range,
-          });
-        } else {
-          requiredVersion = base;
-        }
+        // versions[key] is the raw value from package.json (e.g. '^1.2.3' or '1.2.3').
+        const base = versions[key]!;
+        const autoOpts = isAutoObject ? requiredVersionCfg : undefined;
+        requiredVersion = applyAutoRequiredOptions(base, {
+          range: autoOpts?.range,
+          version: autoOpts?.version ?? config.version,
+        });
       } else {
-        requiredVersion = config.requiredVersion as string;
+        requiredVersion = requiredVersionCfg as string;
       }
 
       if (!sharedExternals[key]) {
@@ -196,22 +196,27 @@ export function shareCore(
     if (
       shareObject.requiredVersion === 'auto' ||
       (isInferVersion() && typeof shareObject.requiredVersion === 'undefined') ||
-      (typeof shareObject.requiredVersion === 'object' &&
-        (shareObject.requiredVersion as any).mode === undefined) ||
+      typeof shareObject.requiredVersion === 'object' ||
       (shareObject.requiredVersion?.length ?? 1) < 1
     ) {
-      // Determine actual requiredVersion value, optionally applying range formatting.
-      const raw = lookupVersion(key, projectPath, repo);
+      const requiredVersionCfg = shareObject.requiredVersion as
+        | string
+        | AutoRequiredOptions
+        | undefined;
+      const isAutoObject = typeof requiredVersionCfg === 'object';
 
-      if (typeof shareObject.requiredVersion === 'object' && (shareObject.requiredVersion as any).range) {
-        const opts = shareObject.requiredVersion as any;
-        const resolved = applyAutoRequiredOptions(raw, {
-          range: opts.range,
-        });
-        shareObject.requiredVersion = resolved;
-      } else {
-        shareObject.requiredVersion = raw;
-      }
+      const explicitVersion =
+        (isAutoObject ? requiredVersionCfg.version : undefined) ?? shareObject.version;
+      const resolvedVersion =
+        explicitVersion && explicitVersion !== 'auto' ? explicitVersion : undefined;
+
+      // raw already carries the explicit version, if any — no need to pass it again below.
+      const raw = resolvedVersion ?? lookupVersion(key, projectPath, repo);
+
+      shareObject.requiredVersion =
+        isAutoObject && requiredVersionCfg.range
+          ? applyAutoRequiredOptions(raw, { range: requiredVersionCfg.range })
+          : raw;
 
       // Keep the numeric version for cache/installed-version tracking (strip non-digits).
       shareObject.version = raw.replace(/^\D*/, '');

--- a/src/lib/config/share-utils.ts
+++ b/src/lib/config/share-utils.ts
@@ -19,7 +19,7 @@ import type {
   ShareExternalsOptions,
 } from '../domain/config/external-config.contract.js';
 import { findPackageJson, inferProjectPath } from './project-paths.js';
-import { isInferVersion, lookupVersion, resolveAutoRequiredVersion, applyAutoRequiredOptions } from './version-lookup.js';
+import { isInferVersion, lookupVersion, applyAutoRequiredOptions } from './version-lookup.js';
 import { addSecondaries, getSecondaries } from './secondaries.js';
 
 export const fromPackageJson = (baseCfg: ShareAllExternalsOptions, projectPath?: string) => {

--- a/src/lib/config/share-utils.ts
+++ b/src/lib/config/share-utils.ts
@@ -19,7 +19,7 @@ import type {
   ShareExternalsOptions,
 } from '../domain/config/external-config.contract.js';
 import { findPackageJson, inferProjectPath } from './project-paths.js';
-import { isInferVersion, lookupVersion } from './version-lookup.js';
+import { isInferVersion, lookupVersion, resolveAutoRequiredVersion, applyAutoRequiredOptions } from './version-lookup.js';
 import { addSecondaries, getSecondaries } from './secondaries.js';
 
 export const fromPackageJson = (baseCfg: ShareAllExternalsOptions, projectPath?: string) => {
@@ -95,8 +95,27 @@ export function shareAllCore(
         continue;
       }
 
-      const inferVersion = !config.requiredVersion || config.requiredVersion === 'auto';
-      const requiredVersion = inferVersion ? versions[key] : config.requiredVersion;
+      const cfgRequired = (config.requiredVersion ?? undefined) as any;
+      const inferVersion =
+        !cfgRequired ||
+        cfgRequired === 'auto' ||
+        (typeof cfgRequired === 'object' && cfgRequired.mode === 'auto');
+
+      let requiredVersion: string;
+      if (inferVersion) {
+        // versions[key] is the raw value from package.json (e.g. '^1.2.3' or '1.2.3')
+        const base = versions[key];
+        if (typeof cfgRequired === 'object') {
+          requiredVersion = applyAutoRequiredOptions(base, {
+            prefix: cfgRequired.prefix,
+            force: !!cfgRequired.force,
+          });
+        } else {
+          requiredVersion = base;
+        }
+      } else {
+        requiredVersion = config.requiredVersion as string;
+      }
 
       if (!sharedExternals[key]) {
         sharedExternals[key] = { ...config, requiredVersion };
@@ -178,12 +197,25 @@ export function shareCore(
     if (
       shareObject.requiredVersion === 'auto' ||
       (isInferVersion() && typeof shareObject.requiredVersion === 'undefined') ||
+      (typeof shareObject.requiredVersion === 'object' &&
+        (shareObject.requiredVersion as any).mode === 'auto') ||
       (shareObject.requiredVersion?.length ?? 1) < 1
     ) {
-      const version = lookupVersion(key, projectPath, repo);
+      // Determine actual requiredVersion value, optionally applying prefix/force.
+      const raw = lookupVersion(key, projectPath, repo);
 
-      shareObject.requiredVersion = version;
-      shareObject.version = version.replace(/^\D*/, '');
+      if (typeof shareObject.requiredVersion === 'object') {
+        const opts = shareObject.requiredVersion as any;
+        const resolved = applyAutoRequiredOptions(raw, {
+          prefix: opts.prefix,
+          force: !!opts.force,
+        });
+        shareObject.requiredVersion = resolved;
+      } else {
+        shareObject.requiredVersion = raw;
+      }
+      // Keep the numeric version for cache/installed-version tracking (strip non-digits).
+      shareObject.version = raw.replace(/^\D*/, '');
     }
 
     if (typeof shareObject.includeSecondaries === 'undefined') {

--- a/src/lib/config/share-utils.ts
+++ b/src/lib/config/share-utils.ts
@@ -107,11 +107,12 @@ export function shareAllCore(
       if (inferVersion) {
         // versions[key] is the raw value from package.json (e.g. '^1.2.3' or '1.2.3').
         const base = versions[key]!;
-        const autoOpts = isAutoObject ? requiredVersionCfg : undefined;
-        requiredVersion = applyAutoRequiredOptions(base, {
-          range: autoOpts?.range,
-          version: autoOpts?.version ?? config.version,
-        });
+        requiredVersion = isAutoObject
+          ? applyAutoRequiredOptions(base, {
+              range: requiredVersionCfg.range,
+              version: requiredVersionCfg.version ?? config.version,
+            })
+          : base;
       } else {
         requiredVersion = requiredVersionCfg as string;
       }
@@ -205,8 +206,9 @@ export function shareCore(
         | undefined;
       const isAutoObject = typeof requiredVersionCfg === 'object';
 
-      const explicitVersion =
-        (isAutoObject ? requiredVersionCfg.version : undefined) ?? shareObject.version;
+      const explicitVersion = isAutoObject
+        ? requiredVersionCfg.version ?? shareObject.version
+        : undefined;
       const resolvedVersion =
         explicitVersion && explicitVersion !== 'auto' ? explicitVersion : undefined;
 

--- a/src/lib/config/share-utils.ts
+++ b/src/lib/config/share-utils.ts
@@ -99,16 +99,15 @@ export function shareAllCore(
       const inferVersion =
         !cfgRequired ||
         cfgRequired === 'auto' ||
-        (typeof cfgRequired === 'object' && cfgRequired.mode === 'auto');
+        (typeof cfgRequired === 'object' && (cfgRequired.mode === undefined || cfgRequired.mode === 'auto'));
 
       let requiredVersion: string;
       if (inferVersion) {
         // versions[key] is the raw value from package.json (e.g. '^1.2.3' or '1.2.3')
         const base = versions[key];
-        if (typeof cfgRequired === 'object') {
+        if (typeof cfgRequired === 'object' && cfgRequired.range) {
           requiredVersion = applyAutoRequiredOptions(base, {
-            prefix: cfgRequired.prefix,
-            force: !!cfgRequired.force,
+            range: cfgRequired.range,
           });
         } else {
           requiredVersion = base;
@@ -198,22 +197,22 @@ export function shareCore(
       shareObject.requiredVersion === 'auto' ||
       (isInferVersion() && typeof shareObject.requiredVersion === 'undefined') ||
       (typeof shareObject.requiredVersion === 'object' &&
-        (shareObject.requiredVersion as any).mode === 'auto') ||
+        (shareObject.requiredVersion as any).mode === undefined) ||
       (shareObject.requiredVersion?.length ?? 1) < 1
     ) {
-      // Determine actual requiredVersion value, optionally applying prefix/force.
+      // Determine actual requiredVersion value, optionally applying range formatting.
       const raw = lookupVersion(key, projectPath, repo);
 
-      if (typeof shareObject.requiredVersion === 'object') {
+      if (typeof shareObject.requiredVersion === 'object' && (shareObject.requiredVersion as any).range) {
         const opts = shareObject.requiredVersion as any;
         const resolved = applyAutoRequiredOptions(raw, {
-          prefix: opts.prefix,
-          force: !!opts.force,
+          range: opts.range,
         });
         shareObject.requiredVersion = resolved;
       } else {
         shareObject.requiredVersion = raw;
       }
+
       // Keep the numeric version for cache/installed-version tracking (strip non-digits).
       shareObject.version = raw.replace(/^\D*/, '');
     }

--- a/src/lib/config/share-utils.ts
+++ b/src/lib/config/share-utils.ts
@@ -192,18 +192,20 @@ export function shareCore(
 
   for (const key in shareObjects) {
     let includeSecondaries: IncludeSecondariesOptions = false;
-    const shareObject = shareObjects[key]!;
+    const { requiredVersion: requiredVersionCfg, ...rest } = shareObjects[key]!;
+    const shareObject: ExternalConfig = {
+      ...rest,
+      ...(typeof requiredVersionCfg === 'string' && {
+        requiredVersion: requiredVersionCfg,
+      }),
+    };
 
     if (
-      shareObject.requiredVersion === 'auto' ||
-      (isInferVersion() && typeof shareObject.requiredVersion === 'undefined') ||
-      typeof shareObject.requiredVersion === 'object' ||
-      (shareObject.requiredVersion?.length ?? 1) < 1
+      requiredVersionCfg === 'auto' ||
+      (isInferVersion() && typeof requiredVersionCfg === 'undefined') ||
+      typeof requiredVersionCfg === 'object' ||
+      (requiredVersionCfg?.length ?? 1) < 1
     ) {
-      const requiredVersionCfg = shareObject.requiredVersion as
-        | string
-        | AutoRequiredOptions
-        | undefined;
       const isAutoObject = typeof requiredVersionCfg === 'object';
 
       const explicitVersion = isAutoObject

--- a/src/lib/config/version-lookup.ts
+++ b/src/lib/config/version-lookup.ts
@@ -44,3 +44,60 @@ function lookupVersionInMap(key: string, versions: VersionMap): string | null {
   }
   return versions[key]!;
 }
+
+/**
+ * Apply auto-options to a base version string (the value read from package.json).
+ * - If opts is undefined, returns baseVersion unchanged.
+ * - If opts.prefix is provided, tries to prepend it to a simple semver or (when force)
+ *   strip any leading range/prefix chars and replace them.
+ *
+ * Conservative behaviour: complex ranges are left unchanged unless they are a single token
+ * that matches a semver with optional leading range chars.
+ */
+export function applyAutoRequiredOptions(
+  baseVersion: string,
+  opts?: { prefix?: string; force?: boolean }
+): string {
+  if (!opts || (!opts.prefix && !opts.force)) return baseVersion;
+
+  const prefix = opts.prefix ?? '';
+  const force = !!opts.force;
+
+  const raw = (baseVersion ?? '').trim();
+  // Recognize a single-version token possibly prefixed by common chars: ^ ~ = v >= <=
+  // Examples matched: '^1.2.3', '1.2.3', 'v1.2.3', '~1.2.3', '>=1.2.3'
+  const singleTokenMatch = raw.match(/^\s*([=^~v<>]*\s*)?(\d+\.\d+\.\d+(?:[-+.][\w.]+)?)\s*$/);
+  if (!singleTokenMatch) {
+    // Not a simple single token — do not attempt to rewrite complex ranges.
+    return raw;
+  }
+
+  const bareVersion = singleTokenMatch[2];
+
+  if (force) {
+    return `${prefix}${bareVersion}`;
+  }
+
+  // Not force: only add prefix when the raw is an exact semver without range chars
+  const hasRangePrefix = /^[\s]*[=^~<>v]/.test(raw);
+  if (!hasRangePrefix) {
+    return `${prefix}${bareVersion}`;
+  }
+
+  // Already has a range/prefix — leave unchanged.
+  return raw;
+}
+
+/**
+ * Convenience resolver: lookupVersion(key, ...) then apply auto options if provided.
+ * opts may be undefined (no prefixing).
+ */
+export function resolveAutoRequiredVersion(
+  key: string,
+  workspaceRoot: string,
+  repo: PackageJsonRepository,
+  opts?: { prefix?: string; force?: boolean }
+): string {
+  const base = lookupVersion(key, workspaceRoot, repo);
+  return applyAutoRequiredOptions(base, opts);
+}

--- a/src/lib/config/version-lookup.ts
+++ b/src/lib/config/version-lookup.ts
@@ -45,36 +45,34 @@ function lookupVersionInMap(key: string, versions: VersionMap): string | null {
   return versions[key]!;
 }
 
-/**
- * Apply auto-options to a base version string (the value read from package.json).
- * - If opts is undefined or opts.range is not provided, returns baseVersion unchanged.
- * - If opts.range is provided, attempts to format a single-token semver according to the
- *   requested range. Complex multi-comparator ranges are left unchanged.
- */
 export function applyAutoRequiredOptions(
   baseVersion: string,
-  opts?: { range?: 'exact' | '^' | '~' | 'minor' | 'patch' }
+  opts?: { range?: 'exact' | '^' | '~' | 'minor' | 'patch'; version?: string }
 ): string {
-  if (!opts || !opts.range) return baseVersion;
+  const explicit = opts?.version && opts.version !== 'auto' ? opts.version : undefined;
+  const raw = (explicit ?? baseVersion ?? '').trim();
+
+  if (!opts || !opts.range) return raw;
 
   const requested = opts.range;
 
-  const raw = (baseVersion ?? '').trim();
   // Recognize a single-version token possibly prefixed by common chars: ^ ~ = v >= <=
-  // Examples matched: '^1.2.3', '1.2.3', 'v1.2.3', '~1.2.3', '>=1.2.3'
-  // Use a stricter regex to avoid matching non-semver suffixes (allow prerelease/build with - or + only)
-  const singleTokenMatch = raw.match(/^\s*(?:[~^<>=]*\s*)?v?(\d+\.\d+\.\d+(?:[-+][\w.]+)?)\s*$/);
+  // Examples matched: '^1.2.3', '1.2.3', 'v1.2.3', '~1.2.3', '>=1.2.3', '1', '1.2'
+  // Minor/patch segments are optional and default to '0'. Still anchored end-to-end so
+  // complex multi-comparator ranges (e.g. '>=1.0.0 <2.0.0') fall through unchanged.
+  const singleTokenMatch = raw.match(
+    /^(?:[~^<>=]*\s*)?v?(\d+)(?:\.(\d+))?(?:\.(\d+))?((?:[-+][\w.]+)?)$/
+  );
   if (!singleTokenMatch) {
-    // Not a simple single token — do not attempt to rewrite complex ranges.
     return raw;
   }
 
-  const bareVersion = singleTokenMatch[1];
+  const [, major, minor = '0', patch = '0', extra] = singleTokenMatch;
+  const bareVersion = `${major}.${minor}.${patch}${extra}`;
 
-  // Map named options to emitted form. 'minor' => '^', 'patch' => '~'.
   switch (requested) {
     case 'exact':
-      return `${bareVersion}`;
+      return bareVersion;
     case '^':
     case 'minor':
       return `^${bareVersion}`;

--- a/src/lib/config/version-lookup.ts
+++ b/src/lib/config/version-lookup.ts
@@ -47,21 +47,17 @@ function lookupVersionInMap(key: string, versions: VersionMap): string | null {
 
 /**
  * Apply auto-options to a base version string (the value read from package.json).
- * - If opts is undefined, returns baseVersion unchanged.
- * - If opts.prefix is provided, tries to prepend it to a simple semver or (when force)
- *   strip any leading range/prefix chars and replace them.
- *
- * Conservative behaviour: complex ranges are left unchanged unless they are a single token
- * that matches a semver with optional leading range chars.
+ * - If opts is undefined or opts.range is not provided, returns baseVersion unchanged.
+ * - If opts.range is provided, attempts to format a single-token semver according to the
+ *   requested range. Complex multi-comparator ranges are left unchanged.
  */
 export function applyAutoRequiredOptions(
   baseVersion: string,
-  opts?: { prefix?: string; force?: boolean }
+  opts?: { range?: 'exact' | '^' | '~' | 'minor' | 'patch' }
 ): string {
-  if (!opts || (!opts.prefix && !opts.force)) return baseVersion;
+  if (!opts || !opts.range) return baseVersion;
 
-  const prefix = opts.prefix ?? '';
-  const force = !!opts.force;
+  const requested = opts.range;
 
   const raw = (baseVersion ?? '').trim();
   // Recognize a single-version token possibly prefixed by common chars: ^ ~ = v >= <=
@@ -74,29 +70,30 @@ export function applyAutoRequiredOptions(
 
   const bareVersion = singleTokenMatch[2];
 
-  if (force) {
-    return `${prefix}${bareVersion}`;
+  // Map named options to emitted form. 'minor' => '^', 'patch' => '~'.
+  switch (requested) {
+    case 'exact':
+      return `${bareVersion}`;
+    case '^':
+    case 'minor':
+      return `^${bareVersion}`;
+    case '~':
+    case 'patch':
+      return `~${bareVersion}`;
+    default:
+      return raw;
   }
-
-  // Not force: only add prefix when the raw is an exact semver without range chars
-  const hasRangePrefix = /^[\s]*[=^~<>v]/.test(raw);
-  if (!hasRangePrefix) {
-    return `${prefix}${bareVersion}`;
-  }
-
-  // Already has a range/prefix — leave unchanged.
-  return raw;
 }
 
 /**
  * Convenience resolver: lookupVersion(key, ...) then apply auto options if provided.
- * opts may be undefined (no prefixing).
+ * opts may be undefined (no formatting).
  */
 export function resolveAutoRequiredVersion(
   key: string,
   workspaceRoot: string,
   repo: PackageJsonRepository,
-  opts?: { prefix?: string; force?: boolean }
+  opts?: { range?: 'exact' | '^' | '~' | 'minor' | 'patch' }
 ): string {
   const base = lookupVersion(key, workspaceRoot, repo);
   return applyAutoRequiredOptions(base, opts);

--- a/src/lib/config/version-lookup.ts
+++ b/src/lib/config/version-lookup.ts
@@ -84,17 +84,3 @@ export function applyAutoRequiredOptions(
       return raw;
   }
 }
-
-/**
- * Convenience resolver: lookupVersion(key, ...) then apply auto options if provided.
- * opts may be undefined (no formatting).
- */
-export function resolveAutoRequiredVersion(
-  key: string,
-  workspaceRoot: string,
-  repo: PackageJsonRepository,
-  opts?: { range?: 'exact' | '^' | '~' | 'minor' | 'patch' }
-): string {
-  const base = lookupVersion(key, workspaceRoot, repo);
-  return applyAutoRequiredOptions(base, opts);
-}

--- a/src/lib/config/version-lookup.ts
+++ b/src/lib/config/version-lookup.ts
@@ -62,13 +62,14 @@ export function applyAutoRequiredOptions(
   const raw = (baseVersion ?? '').trim();
   // Recognize a single-version token possibly prefixed by common chars: ^ ~ = v >= <=
   // Examples matched: '^1.2.3', '1.2.3', 'v1.2.3', '~1.2.3', '>=1.2.3'
-  const singleTokenMatch = raw.match(/^\s*([=^~v<>]*\s*)?(\d+\.\d+\.\d+(?:[-+.][\w.]+)?)\s*$/);
+  // Use a stricter regex to avoid matching non-semver suffixes (allow prerelease/build with - or + only)
+  const singleTokenMatch = raw.match(/^\s*(?:[~^<>=]*\s*)?v?(\d+\.\d+\.\d+(?:[-+][\w.]+)?)\s*$/);
   if (!singleTokenMatch) {
     // Not a simple single token — do not attempt to rewrite complex ranges.
     return raw;
   }
 
-  const bareVersion = singleTokenMatch[2];
+  const bareVersion = singleTokenMatch[1];
 
   // Map named options to emitted form. 'minor' => '^', 'patch' => '~'.
   switch (requested) {

--- a/src/lib/domain/config/external-config.contract.ts
+++ b/src/lib/domain/config/external-config.contract.ts
@@ -15,7 +15,7 @@ export interface AutoRequiredOptions {
 export interface ExternalConfig {
   singleton?: boolean;
   strictVersion?: boolean;
-  requiredVersion?: string | AutoRequiredOptions;
+  requiredVersion?: string;
   version?: string;
   includeSecondaries?: IncludeSecondariesOptions;
   platform?: 'browser' | 'node';
@@ -52,9 +52,11 @@ export type SharedExternalsConfig = Record<string, ExternalConfig>;
 
 export type NormalizedSharedExternalsConfig = Record<string, NormalizedExternalConfig>;
 
-export type ShareAllExternalsOptions = ExternalConfig;
+export type ShareAllExternalsOptions = Omit<ExternalConfig, 'requiredVersion'> & {
+  requiredVersion?: string | AutoRequiredOptions;
+};
 
-export type ShareExternalsOptions = SharedExternalsConfig;
+export type ShareExternalsOptions = Record<string, ShareAllExternalsOptions>;
 
 export type ResolvedExternalConfig = Omit<ExternalConfig, 'includeSecondaries'> & {
   includeSecondaries?: boolean;

--- a/src/lib/domain/config/external-config.contract.ts
+++ b/src/lib/domain/config/external-config.contract.ts
@@ -2,8 +2,7 @@ export type IncludeSecondariesOptions =
   { skip?: string | string[]; resolveGlob?: boolean; keepAll?: boolean } | boolean;
 
 export interface AutoRequiredOptions {
-  /** Optional mode: 'auto' when omitted. */
-  mode?: 'auto' | 'version';
+  version?: 'auto' | string;
   /** Controls how the resolved package.json version is emitted.
    * - 'exact' => "1.2.3"
    * - '^' | '~' => '^1.2.3' or '~1.2.3'
@@ -16,7 +15,6 @@ export interface AutoRequiredOptions {
 export interface ExternalConfig {
   singleton?: boolean;
   strictVersion?: boolean;
-  // Version string (e.g. '^1.2.3') or auto-resolve options.
   requiredVersion?: string | AutoRequiredOptions;
   version?: string;
   includeSecondaries?: IncludeSecondariesOptions;

--- a/src/lib/domain/config/external-config.contract.ts
+++ b/src/lib/domain/config/external-config.contract.ts
@@ -2,12 +2,15 @@ export type IncludeSecondariesOptions =
   { skip?: string | string[]; resolveGlob?: boolean; keepAll?: boolean } | boolean;
 
 export interface AutoRequiredOptions {
-  /** Explicitly indicates auto-resolution. */ 
-  mode?: 'auto';
-  /** Prefix to prepend to the resolved package.json value (e.g. 'v', '^', '~', ''). */
-  prefix?: string;
-  /** When true, strip existing range/prefix characters and replace with prefix. */
-  force?: boolean;
+  /** Optional mode: 'auto' when omitted. */
+  mode?: 'auto' | 'version';
+  /** Controls how the resolved package.json version is emitted.
+   * - 'exact' => "1.2.3"
+   * - '^' | '~' => '^1.2.3' or '~1.2.3'
+   * - 'minor' => maps to '^' (allow minor bumps)
+   * - 'patch' => maps to '~' (allow patch bumps)
+   */
+  range?: 'exact' | '^' | '~' | 'minor' | 'patch';
 }
 
 export interface ExternalConfig {
@@ -15,7 +18,7 @@ export interface ExternalConfig {
   strictVersion?: boolean;
   /**
    * Either a concrete required range string (e.g. '^1.2.3') or an AutoRequiredOptions
-   * object to resolve the value from package.json with optional prefix/force behaviour.
+   * object to resolve the value from package.json with optional range formatting.
    */
   requiredVersion?: string | AutoRequiredOptions;
   version?: string;

--- a/src/lib/domain/config/external-config.contract.ts
+++ b/src/lib/domain/config/external-config.contract.ts
@@ -1,10 +1,23 @@
 export type IncludeSecondariesOptions =
   { skip?: string | string[]; resolveGlob?: boolean; keepAll?: boolean } | boolean;
 
+export interface AutoRequiredOptions {
+  /** Explicitly indicates auto-resolution. */ 
+  mode?: 'auto';
+  /** Prefix to prepend to the resolved package.json value (e.g. 'v', '^', '~', ''). */
+  prefix?: string;
+  /** When true, strip existing range/prefix characters and replace with prefix. */
+  force?: boolean;
+}
+
 export interface ExternalConfig {
   singleton?: boolean;
   strictVersion?: boolean;
-  requiredVersion?: string;
+  /**
+   * Either a concrete required range string (e.g. '^1.2.3') or an AutoRequiredOptions
+   * object to resolve the value from package.json with optional prefix/force behaviour.
+   */
+  requiredVersion?: string | AutoRequiredOptions;
   version?: string;
   includeSecondaries?: IncludeSecondariesOptions;
   platform?: 'browser' | 'node';

--- a/src/lib/domain/config/external-config.contract.ts
+++ b/src/lib/domain/config/external-config.contract.ts
@@ -16,10 +16,7 @@ export interface AutoRequiredOptions {
 export interface ExternalConfig {
   singleton?: boolean;
   strictVersion?: boolean;
-  /**
-   * Either a concrete required range string (e.g. '^1.2.3') or an AutoRequiredOptions
-   * object to resolve the value from package.json with optional range formatting.
-   */
+  // Version string (e.g. '^1.2.3') or auto-resolve options.
   requiredVersion?: string | AutoRequiredOptions;
   version?: string;
   includeSecondaries?: IncludeSecondariesOptions;


### PR DESCRIPTION
Allow `requiredVersion` to be an object so the package.json version can be emitted in a chosen format. This is useful when teams pin versions or use tools like Renovate but want a specific output format.

### API

`ExternalConfig.requiredVersion?: string | { mode?: 'auto' | 'version'; range?: 'exact' | '^' | '\~' | 'minor' | 'patch' }`
`mode` omitted => treated as 'auto' (read version from package.json)

**range:**
'exact' => "1.2.3"
'^' => "^1.2.3"
'\~' => "~1.2.3"
'minor' => maps to '^1.2.3' (allow minor bumps)
'patch' => maps to '~1.2.3' (allow patch bumps)

### Why

Lets consumers control emitted requiredVersion format without changing their package.json.
Helps workflows that pin native versions, produce release tags (v1.2.3), or rely on Renovate semantics, while keeping the package.json canonical.
Conservative: complex multi-comparator ranges (e.g. ">=1.0.0 <2.0.0") are left unchanged.


### What changed

Types: added AutoRequiredOptions replacing force/prefix with range enum and optional mode.
Logic: applyAutoRequiredOptions now maps range -> emitted form (minor -> ^, patch -> ~, exact -> bare).
Integration: shareAll/shareCore resolve object-form requiredVersion when auto is requested.
Tests: added unit tests for exact / ^ / ~ / minor / patch mapping and for preserving complex ranges.

### Compatibility

Backwards compatible: existing requiredVersion strings (including requiredVersion: 'auto' string) keep previous behavior.
No breaking changes expected.