### PR TITLE
fix: stop classifying package-manager symlinks as npm-linked (angular-adapter#130)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,8 +146,10 @@ The library supports **watch mode** for development:
 
 ### The watcher (`createNfWatcher`)
 
-An `fs.watch`-based watcher adapters can use to drive their rebuild loop. It has **two
-channels, both always live**:
+An `fs.watch`-based watcher adapters can use to drive their rebuild loop. A host that
+already owns a watcher can inject it via the `watch` option instead; an injected
+implementation is expected to survive inode replacement itself, since `opts.poll` is only a
+hint (see `file-watcher.contract.ts`). It has **two channels, both always live**:
 
 - **push** — the `onChange` callback, for waking a rebuild loop
 - **pull** — `get()` / `clear()` / `mutate()`, for reading _which_ files changed
@@ -162,7 +164,14 @@ lifetime.
 a cache that records its inputs elsewhere yields an empty watch set and, silently, a dev
 server serving stale bundles until restart (angular-adapter#94). `linkedDirs` (from
 `linkedSharedDirs`) are polled rather than natively watched, because ng-packagr's atomic
-dist rewrites change the inode and defeat `fs.watch`.
+dist rewrites change the inode and defeat `fs.watch`. `linkedSharedDirs` returns `[]`
+unless the `watchLinkedDeps` option is on, so npm-linked shared deps are **not** watched by
+default.
+
+The content signal is a separate mechanism and is **not** gated: `linkedContentSignals`
+walks a linked checkout on every build so an edit under a fixed version still invalidates
+the cached external, whether or not anything is watching. That walk costs ~250 ms on a
+checkout with ~17k vendored files; a pure source checkout is free.
 
 `sharedMappingDirs(config)` is the config-only alternative: the source dir of every
 `sharedMappings` entry point. It is coarser than a build's compiled inputs and covers what

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -39,6 +39,7 @@ export type {
   NfFileWatcherOptions,
 } from './lib/domain/utils/file-watcher.contract.js';
 export { syncNfFileWatcher, createNfWatcher, type WatchSources } from './lib/utils/file-watcher.js';
+export type { WatchPort, WatchHandle } from './lib/domain/utils/io-port.contract.js';
 export { linkedSharedDirs, sharedMappingDirs } from './lib/core/build/resolve-shared-dirs.js';
 // Correlates watcher paths with linkedSharedDirs output; both are posix, so consumers
 // must not hand-roll the prefix check with path.sep.

--- a/src/lib/core/build/build-for-federation.spec.ts
+++ b/src/lib/core/build/build-for-federation.spec.ts
@@ -63,6 +63,7 @@ function makeFedOptions(
     projectName: 'app',
     entryPoints: [],
     cacheExternalArtifacts: false,
+    watchLinkedDeps: false,
     federationCache: {
       externals,
       bundlerCache: {},

--- a/src/lib/core/build/bundle-exposed-and-mappings.spec.ts
+++ b/src/lib/core/build/bundle-exposed-and-mappings.spec.ts
@@ -172,6 +172,7 @@ function makeFedOptions(
     entryPoints: [],
     projectName: 'app',
     cacheExternalArtifacts: false,
+    watchLinkedDeps: false,
     ...overrides,
   };
 }

--- a/src/lib/core/build/bundle-shared.spec.ts
+++ b/src/lib/core/build/bundle-shared.spec.ts
@@ -559,6 +559,77 @@ describe('bundleSharedCore (via injected io, repo and build adapter)', () => {
     });
   });
 
+  // A linked lib rebuilds under a fixed version, so the installed version cannot invalidate
+  // it — the content signal is the only thing standing between an edit and a stale bundle.
+  // Independent of watchLinkedDeps: that option only decides whether the edit is noticed
+  // live, never whether the next build is correct.
+  describe('linked-content invalidation', () => {
+    const linkedAt = (dir: string): PackageJsonRepository => ({
+      getPackageJsonFiles: () => [{ content: {}, directory: '/ws' }],
+      findDepPackageJson: () => `${dir}/package.json`,
+      readJson: () => ({ version: '2.0.0', type: 'module', module: './index.mjs' }),
+      exists: () => false,
+    });
+
+    const build = async (mem: ReturnType<typeof createMemoryIo>, dir: string) => {
+      const adapter = createFakeBuildAdapter({ io: mem });
+      const result = await bundleSharedCore(
+        { io: mem, repo: linkedAt(dir), adapter },
+        fooWith(),
+        makeConfig(),
+        makeFedOptions({ cacheExternalArtifacts: true }),
+        [],
+        BUILD_OPTIONS
+      );
+      return { adapter, result };
+    };
+
+    // npm-linked: node_modules/foo -> /dev/foo, a checkout outside any node_modules tree.
+    const linked = () =>
+      createMemoryIo()
+        .setFile(ROOT_PKG, '{}')
+        .setSymlink('/ws/node_modules/foo', '/dev/foo')
+        .setFile('/dev/foo/index.mjs', 'v1')
+        .setMtime('/dev/foo/index.mjs', 100);
+
+    it('re-uses the cached externals when the linked source is untouched', async () => {
+      const mem = linked();
+
+      await build(mem, '/ws/node_modules/foo');
+      const { adapter } = await build(mem, '/ws/node_modules/foo');
+
+      expect(adapter.calls.setup).toHaveLength(0);
+    });
+
+    it('rebuilds when the linked source changed under an unchanged version', async () => {
+      const mem = linked();
+
+      await build(mem, '/ws/node_modules/foo');
+      mem.setFile('/dev/foo/index.mjs', 'v2').setMtime('/dev/foo/index.mjs', 200);
+      const { adapter } = await build(mem, '/ws/node_modules/foo');
+
+      expect(adapter.calls.setup).toHaveLength(1);
+    });
+
+    // The mirror of the above, in the shape that regressed: under pnpm's default linker
+    // node_modules/foo is a symlink too, but into the virtual store. Its bytes cannot move
+    // under a fixed version, so touching it must not cost a rebuild.
+    it('does not rebuild when a pnpm-installed dep is touched', async () => {
+      const store = '/ws/node_modules/.pnpm/foo@2.0.0/node_modules/foo';
+      const mem = createMemoryIo()
+        .setFile(ROOT_PKG, '{}')
+        .setSymlink('/ws/node_modules/foo', store)
+        .setFile(`${store}/index.mjs`, 'v1')
+        .setMtime(`${store}/index.mjs`, 100);
+
+      await build(mem, '/ws/node_modules/foo');
+      mem.setMtime(`${store}/index.mjs`, 200);
+      const { adapter } = await build(mem, '/ws/node_modules/foo');
+
+      expect(adapter.calls.setup).toHaveLength(0);
+    });
+  });
+
   // A configured packageInfo makes the build skip node_modules entirely, so the key must not
   // track it either — even when that packageInfo carries no version of its own. The missing
   // `version` is reachable in practice: ExternalConfig declares it optional and

--- a/src/lib/core/build/bundle-shared.spec.ts
+++ b/src/lib/core/build/bundle-shared.spec.ts
@@ -158,6 +158,7 @@ function makeFedOptions(
     entryPoints: [],
     projectName: 'app',
     cacheExternalArtifacts: false,
+    watchLinkedDeps: false,
     ...overrides,
   };
 }

--- a/src/lib/core/build/resolve-shared-dirs.spec.ts
+++ b/src/lib/core/build/resolve-shared-dirs.spec.ts
@@ -75,6 +75,11 @@ describe('resolveSharedPackageDirs', () => {
 });
 
 describe('linkedSharedDirs', () => {
+  // The watch set is opt-in; these cases are about classification, so they enable it.
+  const watching = (shared: Record<string, unknown>) =>
+    ({ shared }) as unknown as NormalizedFederationConfig;
+  const opts = { workspaceRoot: '/ws', watchLinkedDeps: true } as NormalizedFederationOptions;
+
   function repoReturning(map: Record<string, string | null>): PackageJsonRepository {
     return {
       findDepPackageJson: (name: string) => map[name] ?? null,
@@ -85,10 +90,7 @@ describe('linkedSharedDirs', () => {
   }
 
   it('returns realpath dirs of symlinked packages only, deduped', () => {
-    const cfg = {
-      shared: { '@scope/lib': {}, '@scope/lib/sub': {}, tslib: {} },
-    } as unknown as NormalizedFederationConfig;
-    const fedOptions = { workspaceRoot: '/ws' } as NormalizedFederationOptions;
+    const cfg = watching({ '@scope/lib': {}, '@scope/lib/sub': {}, tslib: {} });
 
     const io = createMemoryIo()
       .setSymlink('/ws/node_modules/@scope/lib', '/dev/lib')
@@ -100,16 +102,25 @@ describe('linkedSharedDirs', () => {
       tslib: '/ws/node_modules/tslib/package.json',
     });
 
-    expect(linkedSharedDirs(cfg, fedOptions, io, repo)).toEqual(['/dev/lib']);
+    expect(linkedSharedDirs(cfg, opts, io, repo)).toEqual(['/dev/lib']);
+  });
+
+  // A registry dep is bundled once and cached by checksum, so watching node_modules can
+  // never change an outcome; only a linked checkout can, and that is opt-in.
+  it('watches nothing unless watchLinkedDeps is enabled', () => {
+    const cfg = watching({ '@scope/lib': {} });
+    const io = createMemoryIo().setSymlink('/ws/node_modules/@scope/lib', '/dev/lib');
+    const repo = repoReturning({ '@scope/lib': '/ws/node_modules/@scope/lib/package.json' });
+    const off = { workspaceRoot: '/ws' } as NormalizedFederationOptions;
+
+    expect(linkedSharedDirs(cfg, off, io, repo)).toEqual([]);
+    expect(linkedSharedDirs(cfg, opts, io, repo)).toEqual(['/dev/lib']);
   });
 
   // pnpm's default (isolated) nodeLinker symlinks *every* dependency into the virtual
   // store, so a bare lstat test classifies the whole graph as npm-linked. angular-adapter#130.
   it('does not treat a package-manager symlink into node_modules as linked', () => {
-    const cfg = {
-      shared: { rxjs: {}, '@scope/lib': {} },
-    } as unknown as NormalizedFederationConfig;
-    const fedOptions = { workspaceRoot: '/ws' } as NormalizedFederationOptions;
+    const cfg = watching({ rxjs: {}, '@scope/lib': {} });
 
     const io = createMemoryIo()
       .setSymlink('/ws/node_modules/rxjs', '/ws/node_modules/.pnpm/rxjs@7.8.1/node_modules/rxjs')
@@ -119,14 +130,13 @@ describe('linkedSharedDirs', () => {
       '@scope/lib': '/ws/node_modules/@scope/lib/package.json',
     });
 
-    expect(linkedSharedDirs(cfg, fedOptions, io, repo)).toEqual(['/dev/lib/dist']);
+    expect(linkedSharedDirs(cfg, opts, io, repo)).toEqual(['/dev/lib/dist']);
   });
 
   // The virtual store can sit above the Angular workspace root in a monorepo, so the
   // rule matches a node_modules segment anywhere rather than under workspaceRoot.
   it('rejects a store that sits above the workspace root', () => {
-    const cfg = { shared: { rxjs: {} } } as unknown as NormalizedFederationConfig;
-    const fedOptions = { workspaceRoot: '/repo/apps/host' } as NormalizedFederationOptions;
+    const cfg = watching({ rxjs: {} });
 
     const io = createMemoryIo().setSymlink(
       '/repo/apps/host/node_modules/rxjs',
@@ -134,14 +144,13 @@ describe('linkedSharedDirs', () => {
     );
     const repo = repoReturning({ rxjs: '/repo/apps/host/node_modules/rxjs/package.json' });
 
-    expect(linkedSharedDirs(cfg, fedOptions, io, repo)).toEqual([]);
+    expect(linkedSharedDirs(cfg, opts, io, repo)).toEqual([]);
   });
 
   // Substring matching would read this checkout as an installed package and silently
   // switch the feature off for it.
   it('treats a checkout whose path merely contains the text node_modules as linked', () => {
-    const cfg = { shared: { 'my-lib': {} } } as unknown as NormalizedFederationConfig;
-    const fedOptions = { workspaceRoot: '/ws' } as NormalizedFederationOptions;
+    const cfg = watching({ 'my-lib': {} });
 
     const io = createMemoryIo().setSymlink(
       '/ws/node_modules/my-lib',
@@ -149,7 +158,7 @@ describe('linkedSharedDirs', () => {
     );
     const repo = repoReturning({ 'my-lib': '/ws/node_modules/my-lib/package.json' });
 
-    expect(linkedSharedDirs(cfg, fedOptions, io, repo)).toEqual([
+    expect(linkedSharedDirs(cfg, opts, io, repo)).toEqual([
       '/dev/node_modules_backup/my-lib/dist',
     ]);
   });
@@ -157,15 +166,14 @@ describe('linkedSharedDirs', () => {
   // `npm link` installs two hops; realpath collapses both to the checkout, which carries
   // no node_modules segment, so the feature survives the narrowed test.
   it('follows a two-hop npm-link chain to the dev checkout', () => {
-    const cfg = { shared: { 'my-lib': {} } } as unknown as NormalizedFederationConfig;
-    const fedOptions = { workspaceRoot: '/ws' } as NormalizedFederationOptions;
+    const cfg = watching({ 'my-lib': {} });
 
     const io = createMemoryIo()
       .setSymlink('/ws/node_modules/my-lib', '/usr/lib/node_modules/my-lib')
       .setSymlink('/usr/lib/node_modules/my-lib', '/dev/mylib-checkout/dist');
     const repo = repoReturning({ 'my-lib': '/ws/node_modules/my-lib/package.json' });
 
-    expect(linkedSharedDirs(cfg, fedOptions, io, repo)).toEqual(['/dev/mylib-checkout/dist']);
+    expect(linkedSharedDirs(cfg, opts, io, repo)).toEqual(['/dev/mylib-checkout/dist']);
   });
 });
 

--- a/src/lib/core/build/resolve-shared-dirs.spec.ts
+++ b/src/lib/core/build/resolve-shared-dirs.spec.ts
@@ -306,9 +306,10 @@ describe('linkedContentSignals', () => {
     expect(readDir.mock.calls.filter(([dir]) => dir === '/dev/lib')).toHaveLength(1);
   });
 
-  // io.isDirectory is stat-based and follows links, so an unguarded walk would descend
-  // a linked node_modules and pick up mtimes from an unrelated tree.
-  it('does not descend a nested node_modules', () => {
+  // bundle-shared marks only shared keys external, so a dep installed inside the linked
+  // checkout is compiled into the external and has to move the signal — an `npm install`
+  // in the checkout changes the emitted bundle while the shared version stays put.
+  it('includes a real nested node_modules in the signal', () => {
     const io = createMemoryIo()
       .setSymlink('/ws/node_modules/@scope/lib', '/dev/lib')
       .setFile('/dev/lib/a.js', 'A')
@@ -316,6 +317,38 @@ describe('linkedContentSignals', () => {
       .setFile('/dev/lib/node_modules/dep/index.js', 'D')
       .setMtime('/dev/lib/node_modules/dep/index.js', 900);
 
+    expect(linkedContentSignals(['@scope/lib'], '/ws', io, repo)['@scope/lib']).toBe('900');
+  });
+
+  // The escape the walk actually has to guard: io.isDirectory follows links, so descending
+  // one leaves the package. Deliberately not named node_modules — the old name-based skip
+  // happened to cover that one path and nothing else.
+  it('does not descend a symlinked directory', () => {
+    const io = createMemoryIo()
+      .setSymlink('/ws/node_modules/@scope/lib', '/dev/lib')
+      .setFile('/dev/lib/a.js', 'A')
+      .setMtime('/dev/lib/a.js', 100)
+      // A symlinked dir: lstat reports the link, isDirectory follows it to a real dir.
+      .setDir('/other/pkg')
+      .setSymlink('/dev/lib/vendor', '/other/pkg')
+      .setFile('/other/pkg/index.js', 'D')
+      .setMtime('/other/pkg/index.js', 900);
+
     expect(linkedContentSignals(['@scope/lib'], '/ws', io, repo)['@scope/lib']).toBe('100');
+  });
+
+  // Same guard, and the case that would otherwise not terminate: descending `self` reads
+  // /dev/lib again, whose own `self` reads it again. Counting reads is what pins this down —
+  // the signal alone stays 100 either way.
+  it('does not follow a symlink pointing back at an ancestor', () => {
+    const io = createMemoryIo()
+      .setSymlink('/ws/node_modules/@scope/lib', '/dev/lib')
+      .setFile('/dev/lib/a.js', 'A')
+      .setMtime('/dev/lib/a.js', 100)
+      .setSymlink('/dev/lib/self', '/dev/lib');
+    const readDir = vi.spyOn(io, 'readDir');
+
+    expect(linkedContentSignals(['@scope/lib'], '/ws', io, repo)['@scope/lib']).toBe('100');
+    expect(readDir).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/core/build/resolve-shared-dirs.spec.ts
+++ b/src/lib/core/build/resolve-shared-dirs.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   affectedSharedKeys,
   linkedContentSignals,
@@ -102,6 +102,54 @@ describe('linkedSharedDirs', () => {
 
     expect(linkedSharedDirs(cfg, fedOptions, io, repo)).toEqual(['/dev/lib']);
   });
+
+  // pnpm's default (isolated) nodeLinker symlinks *every* dependency into the virtual
+  // store, so a bare lstat test classifies the whole graph as npm-linked. angular-adapter#130.
+  it('does not treat a package-manager symlink into node_modules as linked', () => {
+    const cfg = {
+      shared: { rxjs: {}, '@scope/lib': {} },
+    } as unknown as NormalizedFederationConfig;
+    const fedOptions = { workspaceRoot: '/ws' } as NormalizedFederationOptions;
+
+    const io = createMemoryIo()
+      .setSymlink('/ws/node_modules/rxjs', '/ws/node_modules/.pnpm/rxjs@7.8.1/node_modules/rxjs')
+      .setSymlink('/ws/node_modules/@scope/lib', '/dev/lib/dist');
+    const repo = repoReturning({
+      rxjs: '/ws/node_modules/rxjs/package.json',
+      '@scope/lib': '/ws/node_modules/@scope/lib/package.json',
+    });
+
+    expect(linkedSharedDirs(cfg, fedOptions, io, repo)).toEqual(['/dev/lib/dist']);
+  });
+
+  // The virtual store can sit above the Angular workspace root in a monorepo, so the
+  // rule matches a node_modules segment anywhere rather than under workspaceRoot.
+  it('rejects a store that sits above the workspace root', () => {
+    const cfg = { shared: { rxjs: {} } } as unknown as NormalizedFederationConfig;
+    const fedOptions = { workspaceRoot: '/repo/apps/host' } as NormalizedFederationOptions;
+
+    const io = createMemoryIo().setSymlink(
+      '/repo/apps/host/node_modules/rxjs',
+      '/repo/node_modules/.pnpm/rxjs@7.8.1/node_modules/rxjs'
+    );
+    const repo = repoReturning({ rxjs: '/repo/apps/host/node_modules/rxjs/package.json' });
+
+    expect(linkedSharedDirs(cfg, fedOptions, io, repo)).toEqual([]);
+  });
+
+  // `npm link` installs two hops; realpath collapses both to the checkout, which carries
+  // no node_modules segment, so the feature survives the narrowed test.
+  it('follows a two-hop npm-link chain to the dev checkout', () => {
+    const cfg = { shared: { 'my-lib': {} } } as unknown as NormalizedFederationConfig;
+    const fedOptions = { workspaceRoot: '/ws' } as NormalizedFederationOptions;
+
+    const io = createMemoryIo()
+      .setSymlink('/ws/node_modules/my-lib', '/usr/lib/node_modules/my-lib')
+      .setSymlink('/usr/lib/node_modules/my-lib', '/dev/mylib-checkout/dist');
+    const repo = repoReturning({ 'my-lib': '/ws/node_modules/my-lib/package.json' });
+
+    expect(linkedSharedDirs(cfg, fedOptions, io, repo)).toEqual(['/dev/mylib-checkout/dist']);
+  });
 });
 
 describe('sharedMappingDirs', () => {
@@ -204,5 +252,45 @@ describe('linkedContentSignals', () => {
     const signals = linkedContentSignals(['@scope/lib'], '/ws', io, repo);
 
     expect(signals['@scope/lib']).toBe('500');
+  });
+
+  it('emits no signal for a package-manager symlink into node_modules', () => {
+    const io = createMemoryIo()
+      .setSymlink('/ws/node_modules/tslib', '/ws/node_modules/.pnpm/tslib@2.6.2/node_modules/tslib')
+      .setFile('/ws/node_modules/.pnpm/tslib@2.6.2/node_modules/tslib/index.js', 'T')
+      .setMtime('/ws/node_modules/.pnpm/tslib@2.6.2/node_modules/tslib/index.js', 900);
+
+    expect(linkedContentSignals(['tslib'], '/ws', io, repo)).toEqual({});
+  });
+
+  it('walks each unique package dir once, however many keys resolve to it', () => {
+    const io = createMemoryIo()
+      .setSymlink('/ws/node_modules/@scope/lib', '/dev/lib')
+      .setSymlink('/ws/node_modules/@scope/lib/sub', '/dev/lib')
+      .setFile('/dev/lib/a.js', 'A')
+      .setMtime('/dev/lib/a.js', 100);
+    const multiEntry = repoReturning({
+      '@scope/lib': '/ws/node_modules/@scope/lib/package.json',
+      '@scope/lib/sub': '/ws/node_modules/@scope/lib/package.json',
+    });
+    const readDir = vi.spyOn(io, 'readDir');
+
+    const signals = linkedContentSignals(['@scope/lib', '@scope/lib/sub'], '/ws', io, multiEntry);
+
+    expect(signals).toEqual({ '@scope/lib': '100', '@scope/lib/sub': '100' });
+    expect(readDir.mock.calls.filter(([dir]) => dir === '/dev/lib')).toHaveLength(1);
+  });
+
+  // io.isDirectory is stat-based and follows links, so an unguarded walk would descend
+  // a linked node_modules and pick up mtimes from an unrelated tree.
+  it('does not descend a nested node_modules', () => {
+    const io = createMemoryIo()
+      .setSymlink('/ws/node_modules/@scope/lib', '/dev/lib')
+      .setFile('/dev/lib/a.js', 'A')
+      .setMtime('/dev/lib/a.js', 100)
+      .setFile('/dev/lib/node_modules/dep/index.js', 'D')
+      .setMtime('/dev/lib/node_modules/dep/index.js', 900);
+
+    expect(linkedContentSignals(['@scope/lib'], '/ws', io, repo)['@scope/lib']).toBe('100');
   });
 });

--- a/src/lib/core/build/resolve-shared-dirs.spec.ts
+++ b/src/lib/core/build/resolve-shared-dirs.spec.ts
@@ -137,6 +137,23 @@ describe('linkedSharedDirs', () => {
     expect(linkedSharedDirs(cfg, fedOptions, io, repo)).toEqual([]);
   });
 
+  // Substring matching would read this checkout as an installed package and silently
+  // switch the feature off for it.
+  it('treats a checkout whose path merely contains the text node_modules as linked', () => {
+    const cfg = { shared: { 'my-lib': {} } } as unknown as NormalizedFederationConfig;
+    const fedOptions = { workspaceRoot: '/ws' } as NormalizedFederationOptions;
+
+    const io = createMemoryIo().setSymlink(
+      '/ws/node_modules/my-lib',
+      '/dev/node_modules_backup/my-lib/dist'
+    );
+    const repo = repoReturning({ 'my-lib': '/ws/node_modules/my-lib/package.json' });
+
+    expect(linkedSharedDirs(cfg, fedOptions, io, repo)).toEqual([
+      '/dev/node_modules_backup/my-lib/dist',
+    ]);
+  });
+
   // `npm link` installs two hops; realpath collapses both to the checkout, which carries
   // no node_modules segment, so the feature survives the narrowed test.
   it('follows a two-hop npm-link chain to the dev checkout', () => {

--- a/src/lib/core/build/resolve-shared-dirs.ts
+++ b/src/lib/core/build/resolve-shared-dirs.ts
@@ -53,13 +53,18 @@ export function resolveSharedPackageDirs(
 }
 
 /** Realpath'd dirs of symlinked shared packages — the bounded watch set.
- *  Deduped, since secondaries share a package dir. */
+ *  Deduped, since secondaries share a package dir.
+ *
+ *  Empty unless `fedOptions.watchLinkedDeps` is on. A registry dep is bundled once and
+ *  cached by checksum, so watching it can never change an outcome; only a linked dev
+ *  checkout changes content under a fixed version, and paying for that is opt-in. */
 export function linkedSharedDirs(
   config: NormalizedFederationConfig,
   fedOptions: NormalizedFederationOptions,
   io: FileReaderPort = nodeIo,
   repo: PackageJsonRepository = sharedPackageJsonRepository
 ): string[] {
+  if (!fedOptions.watchLinkedDeps) return [];
   const entries = resolveEntries(Object.keys(config.shared), folderOf(fedOptions), io, repo);
   return [...new Set(entries.filter(e => e.isSymlink).map(e => e.realDir))];
 }

--- a/src/lib/core/build/resolve-shared-dirs.ts
+++ b/src/lib/core/build/resolve-shared-dirs.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import type { NormalizedFederationConfig } from '../../domain/config/federation-config.contract.js';
 import type { NormalizedFederationOptions } from '../../domain/core/federation-options.contract.js';
-import type { FileReaderPort } from '../../domain/utils/io-port.contract.js';
+import type { FileReaderPort, StatInfo } from '../../domain/utils/io-port.contract.js';
 import type { PackageJsonRepository } from '../../domain/utils/package-json.contract.js';
 import { nodeIo } from '../../utils/io/node-io-adapter.js';
 import { sharedPackageJsonRepository } from '../../utils/package/package-info.js';
@@ -88,19 +88,23 @@ export function sharedMappingDirs(config: NormalizedFederationConfig): string[] 
 
 function maxMtime(io: FileReaderPort, dir: string): number {
   let max = 0;
+  const bump = (s: StatInfo | null) => {
+    if (s && s.mtimeMs > max) max = s.mtimeMs;
+  };
   const walk = (d: string) => {
     for (const name of io.readDir(d)) {
-      // io.isDirectory follows links, so an unguarded walk can wander out of the package.
-      if (name === 'node_modules') continue;
       const full = path.join(d, name);
-      if (io.isDirectory(full)) walk(full);
-      else {
-        let s = io.stat(full);
-        // stat is lstat-based: a symlinked file reports the link's own mtime, not the
-        // target's. Follow it so an edit to the real file still moves the signal.
-        if (s?.isSymbolicLink) s = io.stat(io.realpath(full));
-        if (s && s.mtimeMs > max) max = s.mtimeMs;
+      // stat is lstat-based, so this reports the link itself, not its target.
+      const entry = io.stat(full);
+      if (entry?.isSymbolicLink) {
+        // Never descend a linked dir: io.isDirectory follows links, so the walk would
+        // wander out of the package (pnpm's store, a workspace sibling) or back at an
+        // ancestor. A linked file still follows, so editing the real file moves the signal.
+        if (!io.isDirectory(full)) bump(io.stat(io.realpath(full)));
+        continue;
       }
+      if (io.isDirectory(full)) walk(full);
+      else bump(entry);
     }
   };
   walk(dir);

--- a/src/lib/core/build/resolve-shared-dirs.ts
+++ b/src/lib/core/build/resolve-shared-dirs.ts
@@ -5,7 +5,7 @@ import type { FileReaderPort } from '../../domain/utils/io-port.contract.js';
 import type { PackageJsonRepository } from '../../domain/utils/package-json.contract.js';
 import { nodeIo } from '../../utils/io/node-io-adapter.js';
 import { sharedPackageJsonRepository } from '../../utils/package/package-info.js';
-import { isUnderDir, toPosix } from '../../utils/path-patterns.js';
+import { isOutsideNodeModules, isUnderDir, toPosix } from '../../utils/path-patterns.js';
 
 interface SharedEntry {
   key: string;
@@ -28,10 +28,13 @@ function resolveEntries(
     const pkgJsonPath = repo.findDepPackageJson(key, folder);
     if (!pkgJsonPath) continue;
     const pkgDir = path.dirname(pkgJsonPath);
+    const realDir = toPosix(io.realpath(pkgDir));
     out.push({
       key,
-      realDir: toPosix(io.realpath(pkgDir)),
-      isSymlink: !!io.stat(pkgDir)?.isSymbolicLink,
+      realDir,
+      // A symlink resolving back into a node_modules tree is an install layout, not a
+      // dev checkout: under pnpm's default linker that is every dependency.
+      isSymlink: !!io.stat(pkgDir)?.isSymbolicLink && isOutsideNodeModules(realDir),
     });
   }
   return out;
@@ -79,7 +82,7 @@ export function linkedSharedDirs(
 export function sharedMappingDirs(config: NormalizedFederationConfig): string[] {
   const dirs = Object.keys(config.sharedMappings)
     .map(entryPoint => toPosix(path.dirname(entryPoint)))
-    .filter(dir => !dir.includes('node_modules'));
+    .filter(isOutsideNodeModules);
   return [...new Set(dirs)];
 }
 
@@ -87,6 +90,9 @@ function maxMtime(io: FileReaderPort, dir: string): number {
   let max = 0;
   const walk = (d: string) => {
     for (const name of io.readDir(d)) {
+      // io.isDirectory is stat-based and so follows links: without this a nested or
+      // symlinked node_modules drags an arbitrary amount of unrelated tree into the walk.
+      if (name === 'node_modules') continue;
       const full = path.join(d, name);
       if (io.isDirectory(full)) walk(full);
       else {
@@ -112,8 +118,17 @@ export function linkedContentSignals(
   repo: PackageJsonRepository = sharedPackageJsonRepository
 ): Record<string, string> {
   const signals: Record<string, string> = {};
+  // Per unique dir, not per key: secondary entry points of one package resolve to the
+  // same dir, and each walk is a full recursive stat of it.
+  const byDir = new Map<string, string>();
   for (const entry of resolveEntries(keys, folder, io, repo)) {
-    if (entry.isSymlink) signals[entry.key] = String(maxMtime(io, entry.realDir));
+    if (!entry.isSymlink) continue;
+    let signal = byDir.get(entry.realDir);
+    if (signal === undefined) {
+      signal = String(maxMtime(io, entry.realDir));
+      byDir.set(entry.realDir, signal);
+    }
+    signals[entry.key] = signal;
   }
   return signals;
 }

--- a/src/lib/core/build/resolve-shared-dirs.ts
+++ b/src/lib/core/build/resolve-shared-dirs.ts
@@ -32,8 +32,7 @@ function resolveEntries(
     out.push({
       key,
       realDir,
-      // A symlink resolving back into a node_modules tree is an install layout, not a
-      // dev checkout: under pnpm's default linker that is every dependency.
+      // pnpm's default linker symlinks every dep, so the link alone proves nothing.
       isSymlink: !!io.stat(pkgDir)?.isSymbolicLink && isOutsideNodeModules(realDir),
     });
   }
@@ -53,11 +52,7 @@ export function resolveSharedPackageDirs(
 }
 
 /** Realpath'd dirs of symlinked shared packages — the bounded watch set.
- *  Deduped, since secondaries share a package dir.
- *
- *  Empty unless `fedOptions.watchLinkedDeps` is on. A registry dep is bundled once and
- *  cached by checksum, so watching it can never change an outcome; only a linked dev
- *  checkout changes content under a fixed version, and paying for that is opt-in. */
+ *  Deduped, since secondaries share a package dir. Empty unless `watchLinkedDeps` is on. */
 export function linkedSharedDirs(
   config: NormalizedFederationConfig,
   fedOptions: NormalizedFederationOptions,
@@ -95,8 +90,7 @@ function maxMtime(io: FileReaderPort, dir: string): number {
   let max = 0;
   const walk = (d: string) => {
     for (const name of io.readDir(d)) {
-      // io.isDirectory is stat-based and so follows links: without this a nested or
-      // symlinked node_modules drags an arbitrary amount of unrelated tree into the walk.
+      // io.isDirectory follows links, so an unguarded walk can wander out of the package.
       if (name === 'node_modules') continue;
       const full = path.join(d, name);
       if (io.isDirectory(full)) walk(full);
@@ -123,8 +117,7 @@ export function linkedContentSignals(
   repo: PackageJsonRepository = sharedPackageJsonRepository
 ): Record<string, string> {
   const signals: Record<string, string> = {};
-  // Per unique dir, not per key: secondary entry points of one package resolve to the
-  // same dir, and each walk is a full recursive stat of it.
+  // Secondaries resolve to one dir and each walk is a full recursive stat, so do it once.
   const byDir = new Map<string, string>();
   for (const entry of resolveEntries(keys, folder, io, repo)) {
     if (!entry.isSymlink) continue;

--- a/src/lib/core/build/resolve-shared-dirs.ts
+++ b/src/lib/core/build/resolve-shared-dirs.ts
@@ -11,7 +11,7 @@ interface SharedEntry {
   key: string;
   /** realpath'd package directory (symlink resolved to its dev checkout). */
   realDir: string;
-  isSymlink: boolean;
+  isLinkedCheckout: boolean;
 }
 
 const folderOf = (fedOptions: NormalizedFederationOptions): string =>
@@ -33,7 +33,7 @@ function resolveEntries(
       key,
       realDir,
       // pnpm's default linker symlinks every dep, so the link alone proves nothing.
-      isSymlink: !!io.stat(pkgDir)?.isSymbolicLink && isOutsideNodeModules(realDir),
+      isLinkedCheckout: !!io.stat(pkgDir)?.isSymbolicLink && isOutsideNodeModules(realDir),
     });
   }
   return out;
@@ -61,7 +61,7 @@ export function linkedSharedDirs(
 ): string[] {
   if (!fedOptions.watchLinkedDeps) return [];
   const entries = resolveEntries(Object.keys(config.shared), folderOf(fedOptions), io, repo);
-  return [...new Set(entries.filter(e => e.isSymlink).map(e => e.realDir))];
+  return [...new Set(entries.filter(e => e.isLinkedCheckout).map(e => e.realDir))];
 }
 
 /**
@@ -111,9 +111,12 @@ function maxMtime(io: FileReaderPort, dir: string): number {
   return max;
 }
 
-/** Per-key content signal (max mtime of the resolved dir) for symlinked deps only.
+/** Per-key content signal (max mtime of the resolved dir) for linked checkouts only.
  *  Registry deps get no signal, keeping their checksum version-only. (Every key is
- *  still resolved: detecting the symlink requires the realpath + lstat.) */
+ *  still resolved: detecting the symlink requires the realpath + lstat.)
+ *
+ *  Deliberately not gated on `watchLinkedDeps`: that option decides whether an edit is
+ *  noticed live, never whether the next build is correct. */
 export function linkedContentSignals(
   keys: string[],
   folder: string,
@@ -124,7 +127,7 @@ export function linkedContentSignals(
   // Secondaries resolve to one dir and each walk is a full recursive stat, so do it once.
   const byDir = new Map<string, string>();
   for (const entry of resolveEntries(keys, folder, io, repo)) {
-    if (!entry.isSymlink) continue;
+    if (!entry.isLinkedCheckout) continue;
     let signal = byDir.get(entry.realDir);
     if (signal === undefined) {
       signal = String(maxMtime(io, entry.realDir));

--- a/src/lib/core/normalize-options.ts
+++ b/src/lib/core/normalize-options.ts
@@ -93,6 +93,7 @@ export async function normalizeFederationOptionsCore<TBundlerCache = undefined>(
     entryPoints: options.entryPoints ?? Object.values(config.exposes ?? {}).map(e => e.file),
     projectName,
     cacheExternalArtifacts: options.cacheExternalArtifacts ?? true,
+    watchLinkedDeps: options.watchLinkedDeps ?? false,
     federationCache,
   };
 

--- a/src/lib/domain/core/federation-options.contract.ts
+++ b/src/lib/domain/core/federation-options.contract.ts
@@ -11,6 +11,12 @@ export interface FederationOptions {
   verbose?: boolean;
   dev?: boolean;
   watch?: boolean;
+  /** Poll-watch npm-linked shared deps so a rebuild of the linked lib live-reloads the
+   *  host. Off by default: a registry dep is bundled once and cached by checksum, so
+   *  watching node_modules can never change an outcome, and the walk costs real CPU for
+   *  as long as the dev server runs. Checksums track linked content either way, so with
+   *  this off a linked lib still re-bundles on the next build — it just is not live. */
+  watchLinkedDeps?: boolean;
   packageJson?: string;
   entryPoints?: string[];
   buildNotifications?: BuildNotificationOptions;
@@ -21,4 +27,5 @@ export interface NormalizedFederationOptions<TBundlerCache = unknown> extends Fe
   entryPoints: string[];
   projectName: string;
   cacheExternalArtifacts: boolean;
+  watchLinkedDeps: boolean;
 }

--- a/src/lib/domain/core/federation-options.contract.ts
+++ b/src/lib/domain/core/federation-options.contract.ts
@@ -11,11 +11,10 @@ export interface FederationOptions {
   verbose?: boolean;
   dev?: boolean;
   watch?: boolean;
-  /** Poll-watch npm-linked shared deps so a rebuild of the linked lib live-reloads the
-   *  host. Off by default: a registry dep is bundled once and cached by checksum, so
-   *  watching node_modules can never change an outcome, and the walk costs real CPU for
-   *  as long as the dev server runs. Checksums track linked content either way, so with
-   *  this off a linked lib still re-bundles on the next build — it just is not live. */
+  /** Poll-watch npm-linked shared deps so rebuilding the linked lib live-reloads the host.
+   *  Off by default: a registry dep is bundled once and cached by checksum, so watching
+   *  node_modules cannot change an outcome. With this off a linked lib still re-bundles on
+   *  the next build, it just does not live-reload. */
   watchLinkedDeps?: boolean;
   packageJson?: string;
   entryPoints?: string[];

--- a/src/lib/domain/utils/file-watcher.contract.ts
+++ b/src/lib/domain/utils/file-watcher.contract.ts
@@ -3,7 +3,9 @@ import type { WatchPort } from './io-port.contract.js';
 export interface NfFileWatcherOptions {
   /** Watch implementation, defaulting to Node's fs. The built-in poll is dependency-free
    *  but sweeps the tree every `pollIntervalMs`; a host that already ships a real watcher
-   *  should pass it here. `opts.poll` is a hint an event-driven implementation can ignore. */
+   *  should pass it here. An event-driven implementation may ignore `opts.poll`, but must
+   *  then survive inode replacement on its own: a polled dir supersedes the native watches
+   *  beneath it, so a missed rename-replace is never re-covered. */
   watch?: WatchPort['watch'];
   onChange?: (path: string) => void;
   pollIntervalMs?: number;

--- a/src/lib/domain/utils/file-watcher.contract.ts
+++ b/src/lib/domain/utils/file-watcher.contract.ts
@@ -1,4 +1,10 @@
+import type { WatchPort } from './io-port.contract.js';
+
 export interface NfFileWatcherOptions {
+  /** Watch implementation, defaulting to Node's fs. The built-in poll is dependency-free
+   *  but sweeps the tree every `pollIntervalMs`; a host that already ships a real watcher
+   *  should pass it here. `opts.poll` is a hint an event-driven implementation can ignore. */
+  watch?: WatchPort['watch'];
   onChange?: (path: string) => void;
   pollIntervalMs?: number;
   debounceMs?: number;

--- a/src/lib/utils/file-watcher.spec.ts
+++ b/src/lib/utils/file-watcher.spec.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import { createNfWatcherCore, syncNfFileWatcher } from './file-watcher.js';
 import { createMemoryIo } from './io/__test-helpers__/memory-io.js';
 import { logger } from './logger.js';
+import { toPosix } from './path-patterns.js';
+import type { NfFileWatcherOptions } from '../domain/utils/file-watcher.contract.js';
 
 // A fixed clock keeps the replay grace window (2000ms after a path's mtime)
 // deterministic; memory-io reports mtime 0 unless setMtime says otherwise, which
@@ -124,6 +126,32 @@ describe('createNfWatcherCore', () => {
       expect.objectContaining({ recursive: true, poll: { intervalMs: 250 } }),
       expect.any(Function)
     );
+  });
+
+  // The bundled poll is dependency-free but sweeps the tree; a host that already ships a
+  // real watcher (watchpack, @parcel/watcher) supplies it here instead.
+  it('uses an injected watch implementation in place of the io port', () => {
+    const dir = path.resolve('/proj/src');
+    const io = createMemoryIo().setDir(dir);
+    const ioWatch = vi.spyOn(io, 'watch');
+    const onChange = vi.fn();
+
+    const calls: string[] = [];
+    let emit: (f: string) => void = () => {};
+    const watch = vi.fn((p: string, _o: unknown, cb: (f: string | null) => void) => {
+      calls.push(p);
+      emit = cb;
+      return { close: () => {} };
+    }) as unknown as NonNullable<NfFileWatcherOptions['watch']>;
+
+    const watcher = createNfWatcherCore(io, { watch, onChange });
+    watcher.addPaths(dir, { poll: true });
+
+    expect(calls).toEqual([dir]);
+    expect(ioWatch).not.toHaveBeenCalled();
+
+    emit('a.js');
+    expect(onChange).toHaveBeenCalledWith(toPosix(path.join(dir, 'a.js')));
   });
 
   it('coalesces a burst of events into one delivery per path when debounced', () => {

--- a/src/lib/utils/file-watcher.ts
+++ b/src/lib/utils/file-watcher.ts
@@ -15,6 +15,7 @@ export function createNfWatcherCore(
   now: () => number = Date.now
 ): NfFileWatcher {
   const { onChange } = options;
+  const watch: WatchPort['watch'] = options.watch ?? ((p, o, cb) => io.watch(p, o, cb));
   const pollIntervalMs = options.pollIntervalMs ?? 300;
   const debounceMs = options.debounceMs ?? 0;
   const dedupeReplays = options.dedupeReplays ?? true;
@@ -132,7 +133,7 @@ export function createNfWatcherCore(
           if (watchers.has(dir) || covers(dir, shouldPoll)) continue;
           try {
             watchers.set(dir, {
-              handle: io.watch(p, { recursive: true, poll }, filename => {
+              handle: watch(p, { recursive: true, poll }, filename => {
                 if (filename) notify(toPosix(join(p, filename)));
               }),
               poll: shouldPoll,
@@ -160,7 +161,7 @@ export function createNfWatcherCore(
         if (fileDirWatchers.has(dir)) continue;
         try {
           fileDirWatchers.set(dir, {
-            handle: io.watch(dir, { recursive: false, poll }, filename => {
+            handle: watch(dir, { recursive: false, poll }, filename => {
               if (!filename) return;
               const changed = toPosix(join(dir, filename));
               if (trackedFiles.has(changed)) notify(changed);

--- a/src/lib/utils/file-watcher.ts
+++ b/src/lib/utils/file-watcher.ts
@@ -3,7 +3,7 @@ import type { WatchHandle, WatchPort, FileReaderPort } from '../domain/utils/io-
 import type { NfFileWatcher, NfFileWatcherOptions } from '../domain/utils/file-watcher.contract.js';
 import { nodeIo } from './io/node-io-adapter.js';
 import { logger } from './logger.js';
-import { isUnderDir, toPosix } from './path-patterns.js';
+import { isOutsideNodeModules, isUnderDir, toPosix } from './path-patterns.js';
 
 export function createNfWatcher(options: NfFileWatcherOptions = {}): NfFileWatcher {
   return createNfWatcherCore(nodeIo, options);
@@ -233,7 +233,7 @@ export function syncNfFileWatcher(
   // living under node_modules. See core's `linkedSharedDirs`.
   linkedDirs: readonly string[] = []
 ): void {
-  const files = [...toPaths(sources)].filter(k => !k.includes('node_modules'));
+  const files = [...toPaths(sources)].filter(isOutsideNodeModules);
   if (files.length) watcher.addPaths(files);
   if (linkedDirs.length) watcher.addPaths(linkedDirs, { poll: true });
 }

--- a/src/lib/utils/io/__test-helpers__/memory-io.ts
+++ b/src/lib/utils/io/__test-helpers__/memory-io.ts
@@ -64,6 +64,17 @@ export function createMemoryIo(): MemoryIo {
     return key;
   };
 
+  // Everything in fs except lstat resolves links, so only `stat` sees the link itself.
+  const deref = (p: string): string => {
+    let key = toKey(p);
+    for (let hop = 0; hop < 32; hop++) {
+      const next = resolveOneHop(key);
+      if (next === key) break;
+      key = next;
+    }
+    return key;
+  };
+
   const io: MemoryIo = {
     setFile(filePath, data) {
       const key = toKey(filePath);
@@ -102,35 +113,30 @@ export function createMemoryIo(): MemoryIo {
       return bytes;
     },
     exists(p) {
-      const key = toKey(p);
+      const key = deref(p);
       return files.has(key) || dirs.has(key);
     },
     isFile(p) {
-      return files.has(toKey(p));
+      return files.has(deref(p));
     },
     isDirectory(p) {
-      return dirs.has(toKey(p));
+      return dirs.has(deref(p));
     },
     readDir(p) {
-      const key = toKey(p);
+      const key = deref(p);
       const names = new Set<string>();
-      for (const entry of [...files.keys(), ...dirs]) {
+      // Symlinks are entries too: readdir lists the link, not what it points at.
+      for (const entry of [...files.keys(), ...dirs, ...symlinks.keys()]) {
         if (path.posix.dirname(entry) === key) names.add(path.posix.basename(entry));
       }
       return [...names];
     },
-    realpath(p) {
-      // Chained like fs.realpathSync: `npm link` installs two hops.
-      let key = toKey(p);
-      for (let hop = 0; hop < 32; hop++) {
-        const next = resolveOneHop(key);
-        if (next === key) break;
-        key = next;
-      }
-      return key;
-    },
+    // Chained like fs.realpathSync: `npm link` installs two hops.
+    realpath: deref,
     stat(p): StatInfo | null {
-      const key = toKey(p);
+      const raw = toKey(p);
+      // lstat resolves every component except the last, which stays the link itself.
+      const key = path.posix.join(deref(path.posix.dirname(raw)), path.posix.basename(raw));
       const isSymbolicLink = symlinks.has(key);
       if (!isSymbolicLink && !files.has(key) && !dirs.has(key)) return null;
       return {

--- a/src/lib/utils/io/__test-helpers__/memory-io.ts
+++ b/src/lib/utils/io/__test-helpers__/memory-io.ts
@@ -120,8 +120,7 @@ export function createMemoryIo(): MemoryIo {
       return [...names];
     },
     realpath(p) {
-      // Chained like fs.realpathSync: `npm link` installs two hops
-      // (node_modules/x -> <global prefix>/lib/node_modules/x -> <checkout>).
+      // Chained like fs.realpathSync: `npm link` installs two hops.
       let key = toKey(p);
       for (let hop = 0; hop < 32; hop++) {
         const next = resolveOneHop(key);

--- a/src/lib/utils/io/__test-helpers__/memory-io.ts
+++ b/src/lib/utils/io/__test-helpers__/memory-io.ts
@@ -56,6 +56,14 @@ export function createMemoryIo(): MemoryIo {
     return new RegExp('^' + body + '$');
   };
 
+  const resolveOneHop = (key: string): string => {
+    for (const [link, target] of symlinks) {
+      if (key === link) return target;
+      if (key.startsWith(link + '/')) return target + key.slice(link.length);
+    }
+    return key;
+  };
+
   const io: MemoryIo = {
     setFile(filePath, data) {
       const key = toKey(filePath);
@@ -112,10 +120,13 @@ export function createMemoryIo(): MemoryIo {
       return [...names];
     },
     realpath(p) {
-      const key = toKey(p);
-      for (const [link, target] of symlinks) {
-        if (key === link) return target;
-        if (key.startsWith(link + '/')) return target + key.slice(link.length);
+      // Chained like fs.realpathSync: `npm link` installs two hops
+      // (node_modules/x -> <global prefix>/lib/node_modules/x -> <checkout>).
+      let key = toKey(p);
+      for (let hop = 0; hop < 32; hop++) {
+        const next = resolveOneHop(key);
+        if (next === key) break;
+        key = next;
       }
       return key;
     },

--- a/src/lib/utils/io/node-io-adapter.spec.ts
+++ b/src/lib/utils/io/node-io-adapter.spec.ts
@@ -70,5 +70,31 @@ describe('nodeIo', () => {
 
       expect(seen).toContain('a.js');
     });
+
+    // `npm link` points at the package root, so the linked lib's own installed deps sit
+    // inside the polled dir; walking them every 300ms is what starves the loop.
+    it('does not descend into the linked package own node_modules', () => {
+      fs.writeFileSync(path.join(root, 'index.js'), 'v1');
+      fs.mkdirSync(path.join(root, 'node_modules', 'dep'), { recursive: true });
+      const vendored = path.join(root, 'node_modules', 'dep', 'index.js');
+      fs.writeFileSync(vendored, 'v1');
+
+      const seen: (string | null)[] = [];
+      const handle = nodeIo.watch(root, { recursive: true, poll: { intervalMs: 100 } }, f =>
+        seen.push(f)
+      );
+
+      fs.writeFileSync(vendored, 'v2-changed');
+      vi.advanceTimersByTime(100);
+
+      expect(seen).toEqual([]);
+
+      // the package's own files are still watched
+      fs.writeFileSync(path.join(root, 'index.js'), 'v2-changed');
+      vi.advanceTimersByTime(100);
+      handle.close();
+
+      expect(seen).toContain('index.js');
+    });
   });
 });

--- a/src/lib/utils/io/node-io-adapter.ts
+++ b/src/lib/utils/io/node-io-adapter.ts
@@ -110,9 +110,8 @@ function pollWatch(
         return;
       }
       for (const entry of entries) {
-        // Only linked dirs are polled, and `npm link` points at the package root — so
-        // without this the 300ms snapshot walks the linked lib's own installed deps,
-        // which alone can outrun the interval and starve the loop. angular-adapter#130.
+        // `npm link` points at the package root, so without this the snapshot walks the
+        // linked lib's own deps — enough to outrun the interval and starve the loop.
         if (entry.name === 'node_modules') continue;
         const full = path.join(dir, entry.name);
         if (entry.isDirectory()) {

--- a/src/lib/utils/io/node-io-adapter.ts
+++ b/src/lib/utils/io/node-io-adapter.ts
@@ -110,6 +110,10 @@ function pollWatch(
         return;
       }
       for (const entry of entries) {
+        // Only linked dirs are polled, and `npm link` points at the package root — so
+        // without this the 300ms snapshot walks the linked lib's own installed deps,
+        // which alone can outrun the interval and starve the loop. angular-adapter#130.
+        if (entry.name === 'node_modules') continue;
         const full = path.join(dir, entry.name);
         if (entry.isDirectory()) {
           if (recursive) walk(full);

--- a/src/lib/utils/path-patterns.ts
+++ b/src/lib/utils/path-patterns.ts
@@ -59,3 +59,15 @@ export function substituteWildcard(template: string, captured: string): string {
 export function toGlobPattern({ prefix, suffix }: WildcardPattern): string {
   return prefix.slice(0, prefix.lastIndexOf('/') + 1) + '**/*' + suffix;
 }
+
+/**
+ * True for a directory that sits outside every `node_modules` tree — i.e. a dev checkout
+ * rather than an installed package.
+ *
+ * A symlink alone cannot tell the two apart: package managers that symlink by default
+ * (pnpm's isolated `nodeLinker`, yarn's `nodeLinker: pnpm`) point every dependency at
+ * `<root>/node_modules/.pnpm/<pkg>@<ver>/node_modules/<pkg>`, whereas `npm link` resolves
+ * to the checkout itself. Matching the segment anywhere in the path rather than under the
+ * workspace root matters in a monorepo, where the virtual store can sit above it.
+ */
+export const isOutsideNodeModules = (dir: string): boolean => !toPosix(dir).includes('node_modules');

--- a/src/lib/utils/path-patterns.ts
+++ b/src/lib/utils/path-patterns.ts
@@ -68,6 +68,9 @@ export function toGlobPattern({ prefix, suffix }: WildcardPattern): string {
  * (pnpm's isolated `nodeLinker`, yarn's `nodeLinker: pnpm`) point every dependency at
  * `<root>/node_modules/.pnpm/<pkg>@<ver>/node_modules/<pkg>`, whereas `npm link` resolves
  * to the checkout itself. Matching the segment anywhere in the path rather than under the
- * workspace root matters in a monorepo, where the virtual store can sit above it.
+ * workspace root matters in a monorepo, where the virtual store can sit above it; matching a
+ * whole segment rather than a substring keeps a checkout in `/dev/node_modules_backup/lib`
+ * from reading as an installed package.
  */
-export const isOutsideNodeModules = (dir: string): boolean => !toPosix(dir).includes('node_modules');
+export const isOutsideNodeModules = (dir: string): boolean =>
+  !toPosix(dir).split('/').includes('node_modules');

--- a/src/lib/utils/path-patterns.ts
+++ b/src/lib/utils/path-patterns.ts
@@ -61,16 +61,11 @@ export function toGlobPattern({ prefix, suffix }: WildcardPattern): string {
 }
 
 /**
- * True for a directory that sits outside every `node_modules` tree — i.e. a dev checkout
- * rather than an installed package.
- *
- * A symlink alone cannot tell the two apart: package managers that symlink by default
- * (pnpm's isolated `nodeLinker`, yarn's `nodeLinker: pnpm`) point every dependency at
- * `<root>/node_modules/.pnpm/<pkg>@<ver>/node_modules/<pkg>`, whereas `npm link` resolves
- * to the checkout itself. Matching the segment anywhere in the path rather than under the
- * workspace root matters in a monorepo, where the virtual store can sit above it; matching a
- * whole segment rather than a substring keeps a checkout in `/dev/node_modules_backup/lib`
- * from reading as an installed package.
+ * A dev checkout rather than an installed package. A symlink alone cannot tell them apart:
+ * pnpm's default linker points every dep at `…/node_modules/.pnpm/<pkg>@<ver>/node_modules/
+ * <pkg>`, while `npm link` resolves to the checkout. Matched anywhere in the path, since a
+ * monorepo's store can sit above the workspace root, and by segment so a checkout under
+ * `node_modules_backup` still counts.
  */
 export const isOutsideNodeModules = (dir: string): boolean =>
   !toPosix(dir).split('/').includes('node_modules');


### PR DESCRIPTION
Fixes native-federation/angular-adapter#130.

## The bug

The `npm link` support added in 4.3.2 decided a shared dep was a live dev checkout from one question: is `node_modules/<pkg>` a symlink?

Under pnpm's default isolated `nodeLinker`, **every** dependency is a symlink into `.pnpm/`. So the entire graph was classified as npm-linked, and two behaviours sized for one or two hand-linked packages ran against hundreds:

- a recursive `mtime` walk per shared key on every federation build, and
- a synchronous 300ms poll watch per directory.

Past a certain file count a single snapshot outruns the interval, the `setInterval` callbacks queue back-to-back, and the event loop starves — `ng serve` prints nothing, errors nothing, and never finishes starting. `nodeLinker: hoisted` removes the symlinks, which is why that workaround works.

## What changed

**1. Narrow the linked test.** Require the realpath to sit outside every `node_modules` tree as well. A pnpm dep resolves to `…/node_modules/.pnpm/<pkg>@<ver>/node_modules/<pkg>`; an npm-linked checkout does not, and `realpath` collapses `npm link`'s two hops to the checkout, so the feature survives. `sharedMappingDirs` already applied this rule and now shares the predicate.

**2. Bound the walks.** `linkedContentSignals` walks each unique `realDir` once rather than once per shared key, and both `maxMtime` and `pollWatch` skip `node_modules`. The `pollWatch` one matters most: `npm link` points at the package *root*, so the 300ms snapshot was walking the linked lib's own installed deps.

**3. Watching linked deps is now opt-in** — see the behaviour change below.

**4. A host can supply its own watch implementation** via `NfFileWatcherOptions.watch`, so core needn't grow a native watcher dependency.

## ⚠️ Behaviour change

`watchLinkedDeps` (new `FederationOptions` field) defaults to **false**, so linked-dep live-reload is off unless asked for.

The reasoning: a registry dep is bundled once and cached by checksum, so watching anything under `node_modules` can never change an outcome — its bytes cannot move without its version moving, which moves the checksum anyway. Only a linked dev checkout changes content under a fixed version. This follows Angular, which ignores `**/node_modules/**` by default and only watches through symlinks when `preserveSymlinks` opts in.

The gate covers the **watch only, not `linkedContentSignals`**. The signal is correctness — it is what stops a rebuilt linked lib being served from a stale cache — so it stays on unconditionally. With the option off, a linked lib still re-bundles on the next build; it just does not live-reload.

Two consequences worth a deliberate decision:

- This switches off behaviour that shipped on in 4.3.2 (angular-adapter#55). Nothing breaks and no types break, but someone relying on it will notice. Suggest a minor plus an explicit release note.
- Until the adapter plumbs `watchLinkedDeps` through, there is no way to turn it on, so the feature is dark everywhere. Worth deciding whether the two land together.

Upgrading also costs one extra full re-bundle, since cached checksums contain signals that no longer exist. Self-correcting.

## Measured

Angular 22.1 example on pnpm's default linker, only `@softarc/native-federation`'s `dist` swapped between runs:

| | before | after |
|---|---|---|
| shared keys classified linked | 13 of 13 | 0 |
| `linkedContentSignals` per build | 155 ms | 1.7 ms |
| idle `ng serve` CPU | 65.8% of one core | 0.2% |
| poll cycle over a 12k-file linked checkout | 309 ms (103% of a core) | 55 ms (27%) |

A 309ms cycle against a 300ms interval is the starvation condition itself — so before this, #130's hang was still reachable through the *supported* path by anyone genuinely using `npm link`.

Verified on the real filesystem that a two-hop `npm link` chain is still detected, including when the intermediate hop's own path contains `node_modules`. On a `hoisted` tree, before and after are identical.

## Tests

+13 cases. The cache-invalidation ones were checked by mutation: reverting the `isSymlink` narrowing fails the pnpm case, and dropping the content signal fails the linked-edit case.
