### PR TITLE
feat: Name npm-linked shared packages the watch is skipping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,10 @@ server serving stale bundles until restart (angular-adapter#94). `linkedDirs` (f
 `linkedSharedDirs`) are polled rather than natively watched, because ng-packagr's atomic
 dist rewrites change the inode and defeat `fs.watch`. `linkedSharedDirs` returns `[]`
 unless the `watchLinkedDeps` option is on, so npm-linked shared deps are **not** watched by
-default.
+default. Because a linked lib that never reloads is indistinguishable from a broken one,
+`buildForFederation` names what the default is skipping (`hintUnwatchedLinkedDeps`, gated on
+`watch` and `watchLinkedDeps`). That lives in core rather than in each adapter so the message
+arrives without an adapter change; `rebuildForFederation` does not repeat it.
 
 The content signal is a separate mechanism and is **not** gated: `linkedContentSignals`
 walks a linked checkout on every build so an edit under a fixed version still invalidates

--- a/src/lib/core/build/build-for-federation.spec.ts
+++ b/src/lib/core/build/build-for-federation.spec.ts
@@ -3,6 +3,7 @@ import type { SharedInfo, DenseSharedInfo } from '../../domain/core/federation-i
 import type { NormalizedFederationConfig } from '../../domain/config/federation-config.contract.js';
 import type { NormalizedFederationOptions } from '../../domain/core/federation-options.contract.js';
 import { prepareSkipList } from '../../config/default-skip-list.js';
+import type * as sharedDirs from './resolve-shared-dirs.js';
 
 // Isolate the assembly logic in buildForFederation: no real FS writes, no build adapter.
 vi.mock('../output/write-federation-info.js', () => ({ writeFederationInfo: vi.fn() }));
@@ -11,7 +12,13 @@ vi.mock('./bundle-exposed-and-mappings.js', () => ({
   bundleExposedAndMappings: vi.fn(async () => ({ mappings: [], exposes: [] })),
 }));
 
+vi.mock('./resolve-shared-dirs.js', async importActual => ({
+  ...(await importActual<typeof sharedDirs>()),
+  hintUnwatchedLinkedDeps: vi.fn(),
+}));
+
 const { buildForFederation } = await import('./build-for-federation.js');
+const { hintUnwatchedLinkedDeps } = await import('./resolve-shared-dirs.js');
 const { writeImportMap } = await import('../output/write-import-map.js');
 
 function flat(
@@ -162,5 +169,22 @@ describe('buildForFederation — build notification endpoint', () => {
 
   it('withholds the endpoint when notifications are unconfigured', async () => {
     expect(await buildWith({ dev: true })).toBeUndefined();
+  });
+});
+
+// Adapters call buildForFederation and nothing else to start a session, so the hint has to
+// be triggered here: an adapter that predates the option still gets the message, and none
+// has to opt in. rebuildForFederation is a separate entry point and does not repeat it.
+describe('buildForFederation — unwatched linked deps hint', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('hints once per build, with the config and options it was given', async () => {
+    const config = makeConfig(false);
+    const fedOptions = makeFedOptions(seededExternals(), { watch: true });
+
+    await buildForFederation(config, fedOptions, []);
+
+    expect(hintUnwatchedLinkedDeps).toHaveBeenCalledTimes(1);
+    expect(hintUnwatchedLinkedDeps).toHaveBeenCalledWith(config, fedOptions);
   });
 });

--- a/src/lib/core/build/build-for-federation.ts
+++ b/src/lib/core/build/build-for-federation.ts
@@ -9,6 +9,7 @@ import { AbortedError } from '../../utils/errors.js';
 import type { NormalizedFederationConfig } from '../../domain/config/federation-config.contract.js';
 import { addExternalsToCache } from '../cache/federation-cache.js';
 import { planSharedBundles, type SharedBundlePlan } from './shared-bundle-plan.js';
+import { hintUnwatchedLinkedDeps } from './resolve-shared-dirs.js';
 
 export async function buildForFederation(
   config: NormalizedFederationConfig,
@@ -19,6 +20,7 @@ export async function buildForFederation(
   // 1. Setup
   logger.info('Building federation artifacts');
   logger.notice("Skip packages you don't want to share in your federation config");
+  hintUnwatchedLinkedDeps(config, fedOptions);
 
   // 2. Externals
   await executeSharedBundlePlans(planSharedBundles(config, externals), config, fedOptions, signal);

--- a/src/lib/core/build/resolve-shared-dirs.spec.ts
+++ b/src/lib/core/build/resolve-shared-dirs.spec.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   affectedSharedKeys,
+  hintUnwatchedLinkedDeps,
   linkedContentSignals,
   linkedSharedDirs,
   resolveSharedPackageDirs,
@@ -10,6 +11,7 @@ import { createMemoryIo } from '../../utils/io/__test-helpers__/memory-io.js';
 import type { NormalizedFederationConfig } from '../../domain/config/federation-config.contract.js';
 import type { NormalizedFederationOptions } from '../../domain/core/federation-options.contract.js';
 import type { PackageJsonRepository } from '../../domain/utils/package-json.contract.js';
+import { logger } from '../../utils/logger.js';
 
 describe('affectedSharedKeys', () => {
   const dirs = new Map([
@@ -158,9 +160,7 @@ describe('linkedSharedDirs', () => {
     );
     const repo = repoReturning({ 'my-lib': '/ws/node_modules/my-lib/package.json' });
 
-    expect(linkedSharedDirs(cfg, opts, io, repo)).toEqual([
-      '/dev/node_modules_backup/my-lib/dist',
-    ]);
+    expect(linkedSharedDirs(cfg, opts, io, repo)).toEqual(['/dev/node_modules_backup/my-lib/dist']);
   });
 
   // `npm link` installs two hops; realpath collapses both to the checkout, which carries
@@ -174,6 +174,124 @@ describe('linkedSharedDirs', () => {
     const repo = repoReturning({ 'my-lib': '/ws/node_modules/my-lib/package.json' });
 
     expect(linkedSharedDirs(cfg, opts, io, repo)).toEqual(['/dev/mylib-checkout/dist']);
+  });
+});
+
+describe('hintUnwatchedLinkedDeps', () => {
+  const notice = vi.spyOn(logger, 'notice').mockImplementation(() => undefined);
+  afterEach(() => notice.mockClear());
+
+  const cfg = (shared: Record<string, unknown>) =>
+    ({ shared }) as unknown as NormalizedFederationConfig;
+  const watching = { workspaceRoot: '/ws', watch: true } as NormalizedFederationOptions;
+
+  function repoReturning(map: Record<string, string | null>): PackageJsonRepository {
+    return {
+      findDepPackageJson: (name: string) => map[name] ?? null,
+      getPackageJsonFiles: () => [],
+      readJson: () => ({}),
+      exists: () => true,
+    };
+  }
+
+  const linkedIo = () => createMemoryIo().setSymlink('/ws/node_modules/@scope/lib', '/dev/lib');
+  const linkedRepo = () =>
+    repoReturning({ '@scope/lib': '/ws/node_modules/@scope/lib/package.json' });
+
+  it('names the linked package the watch is skipping', () => {
+    hintUnwatchedLinkedDeps(cfg({ '@scope/lib': {} }), watching, linkedIo(), linkedRepo());
+
+    expect(notice).toHaveBeenCalledTimes(1);
+    const message = String(notice.mock.calls[0]![0]);
+    expect(message).toContain('@scope/lib');
+    expect(message).toContain('watchLinkedDeps');
+  });
+
+  // Only the package is linked, so naming the raw key would point at a path that is not
+  // the thing the user linked.
+  it('names the package, not the secondary entry point that is shared', () => {
+    hintUnwatchedLinkedDeps(
+      cfg({ '@scope/lib/sub': {} }),
+      watching,
+      linkedIo(),
+      repoReturning({ '@scope/lib/sub': '/ws/node_modules/@scope/lib/package.json' })
+    );
+
+    expect(String(notice.mock.calls[0]![0])).toContain('packages: @scope/lib.');
+  });
+
+  // Secondaries resolve to their main package's dir, so they must not each add a name.
+  it('names a package once however many entry points share it', () => {
+    hintUnwatchedLinkedDeps(
+      cfg({ '@scope/lib': {}, '@scope/lib/sub': {} }),
+      watching,
+      linkedIo(),
+      repoReturning({
+        '@scope/lib': '/ws/node_modules/@scope/lib/package.json',
+        '@scope/lib/sub': '/ws/node_modules/@scope/lib/package.json',
+      })
+    );
+
+    expect(String(notice.mock.calls[0]![0])).toContain('packages: @scope/lib.');
+  });
+
+  it('stays quiet when the option is already on', () => {
+    hintUnwatchedLinkedDeps(
+      cfg({ '@scope/lib': {} }),
+      { ...watching, watchLinkedDeps: true },
+      linkedIo(),
+      linkedRepo()
+    );
+
+    expect(notice).not.toHaveBeenCalled();
+  });
+
+  // A one-off build reloads nothing either way, so the option would change nothing.
+  it('stays quiet when the build is not watching', () => {
+    hintUnwatchedLinkedDeps(
+      cfg({ '@scope/lib': {} }),
+      { workspaceRoot: '/ws' } as NormalizedFederationOptions,
+      linkedIo(),
+      linkedRepo()
+    );
+
+    expect(notice).not.toHaveBeenCalled();
+  });
+
+  // The #130 shape: pnpm symlinks the whole graph, and none of it is a dev checkout.
+  it('stays quiet for a symlink that resolves inside node_modules', () => {
+    hintUnwatchedLinkedDeps(
+      cfg({ rxjs: {} }),
+      watching,
+      createMemoryIo().setSymlink(
+        '/ws/node_modules/rxjs',
+        '/ws/node_modules/.pnpm/rxjs@7.8.1/node_modules/rxjs'
+      ),
+      repoReturning({ rxjs: '/ws/node_modules/rxjs/package.json' })
+    );
+
+    expect(notice).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when nothing is linked', () => {
+    hintUnwatchedLinkedDeps(cfg({ rxjs: {} }), watching, createMemoryIo(), repoReturning({}));
+
+    expect(notice).not.toHaveBeenCalled();
+  });
+
+  // The hint is advisory: a repo that cannot resolve must not take the build down with it.
+  it('swallows a resolution failure instead of failing the build', () => {
+    const throwing = {
+      ...repoReturning({}),
+      findDepPackageJson: () => {
+        throw new Error('unresolvable');
+      },
+    } as PackageJsonRepository;
+
+    expect(() =>
+      hintUnwatchedLinkedDeps(cfg({ '@scope/lib': {} }), watching, linkedIo(), throwing)
+    ).not.toThrow();
+    expect(notice).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/core/build/resolve-shared-dirs.ts
+++ b/src/lib/core/build/resolve-shared-dirs.ts
@@ -4,7 +4,11 @@ import type { NormalizedFederationOptions } from '../../domain/core/federation-o
 import type { FileReaderPort, StatInfo } from '../../domain/utils/io-port.contract.js';
 import type { PackageJsonRepository } from '../../domain/utils/package-json.contract.js';
 import { nodeIo } from '../../utils/io/node-io-adapter.js';
-import { sharedPackageJsonRepository } from '../../utils/package/package-info.js';
+import { logger } from '../../utils/logger.js';
+import {
+  getPkgFolder,
+  sharedPackageJsonRepository,
+} from '../../utils/io/package-json-repository.js';
 import { isOutsideNodeModules, isUnderDir, toPosix } from '../../utils/path-patterns.js';
 
 interface SharedEntry {
@@ -62,6 +66,40 @@ export function linkedSharedDirs(
   if (!fedOptions.watchLinkedDeps) return [];
   const entries = resolveEntries(Object.keys(config.shared), folderOf(fedOptions), io, repo);
   return [...new Set(entries.filter(e => e.isLinkedCheckout).map(e => e.realDir))];
+}
+
+/** Names the npm-linked shared packages a watching build leaves unwatched -- see
+ *  AGENTS.md "What to watch". Advisory only, so a resolution failure must not fail the build. */
+export function hintUnwatchedLinkedDeps(
+  config: NormalizedFederationConfig,
+  fedOptions: NormalizedFederationOptions,
+  io: FileReaderPort = nodeIo,
+  repo: PackageJsonRepository = sharedPackageJsonRepository
+): void {
+  if (!fedOptions.watch || fedOptions.watchLinkedDeps) return;
+
+  try {
+    const names = new Map<string, string>();
+    for (const entry of resolveEntries(
+      Object.keys(config.shared),
+      folderOf(fedOptions),
+      io,
+      repo
+    )) {
+      // Secondaries resolve to the package dir their main entry does, so name it once.
+      if (entry.isLinkedCheckout && !names.has(entry.realDir)) {
+        names.set(entry.realDir, getPkgFolder(entry.key));
+      }
+    }
+    if (names.size === 0) return;
+
+    logger.notice(
+      `Detected npm-linked shared packages: ${[...names.values()].join(', ')}. ` +
+        `Set 'watchLinkedDeps' to true to rebuild when they change.`
+    );
+  } catch {
+    /* advisory only */
+  }
 }
 
 /**


### PR DESCRIPTION
`watchLinkedDeps` is off by default, so a linked library that never live-reloads looks exactly like a broken build. buildForFederation now names what the default is skipping, gated on `watch` and on the option itself so it only speaks when turning the option on would change something.

Triggered from core rather than exported for adapters to call: every adapter already goes through buildForFederation to start a session, so the message needs no adapter change to arrive, and rebuilds (rebuildForFederation) do not repeat it.